### PR TITLE
:bug: Ensure updates to error list are not lost

### DIFF
--- a/exp/addons/internal/controllers/clusterresourceset_controller.go
+++ b/exp/addons/internal/controllers/clusterresourceset_controller.go
@@ -18,9 +18,7 @@ package controllers
 
 import (
 	"context"
-	"encoding/base64"
 	"fmt"
-	"sort"
 	"time"
 
 	"github.com/pkg/errors"
@@ -494,47 +492,4 @@ func (r *ClusterResourceSetReconciler) resourceToClusterResourceSet(o client.Obj
 	}
 
 	return result
-}
-
-func getDataListAndHash(resourceKind string, unstructuredData map[string]interface{}, errList []error) ([][]byte, string) {
-	// Since maps are not ordered, we need to order them to get the same hash at each reconcile.
-	keys := make([]string, 0)
-
-	for key := range unstructuredData {
-		keys = append(keys, key)
-	}
-	sort.Strings(keys)
-
-	dataList := make([][]byte, 0)
-	for _, key := range keys {
-		val, ok, err := unstructured.NestedString(unstructuredData, key)
-		if !ok || err != nil {
-			errList = append(errList, errors.New("failed to get value field from the resource"))
-			continue
-		}
-
-		byteArr := []byte(val)
-		// If the resource is a Secret, data needs to be decoded.
-		if resourceKind == string(addonsv1.SecretClusterResourceSetResourceKind) {
-			byteArr, _ = base64.StdEncoding.DecodeString(val)
-		}
-
-		dataList = append(dataList, byteArr)
-	}
-
-	return dataList, computeHash(dataList)
-}
-
-func handleGetResourceErrors(clusterResourceSet *addonsv1.ClusterResourceSet, err error, errList []error) {
-	if err == ErrSecretTypeNotSupported {
-		conditions.MarkFalse(clusterResourceSet, addonsv1.ResourcesAppliedCondition, addonsv1.WrongSecretTypeReason, clusterv1.ConditionSeverityWarning, err.Error())
-	} else {
-		conditions.MarkFalse(clusterResourceSet, addonsv1.ResourcesAppliedCondition, addonsv1.RetrievingResourceFailedReason, clusterv1.ConditionSeverityWarning, err.Error())
-
-		// Continue without adding the error to the aggregate if we can't find the resource.
-		if apierrors.IsNotFound(err) {
-			return
-		}
-	}
-	errList = append(errList, err)
 }

--- a/exp/addons/internal/controllers/clusterresourceset_controller.go
+++ b/exp/addons/internal/controllers/clusterresourceset_controller.go
@@ -215,7 +215,7 @@ func (r *ClusterResourceSetReconciler) getClustersByClusterResourceSetSelector(c
 		return nil, errors.Wrap(err, "failed to list clusters")
 	}
 
-	clusters := make([]*clusterv1.Cluster, 0)
+	clusters := []*clusterv1.Cluster{}
 	for i := range clusterList.Items {
 		c := &clusterList.Items[i]
 		if c.DeletionTimestamp.IsZero() {
@@ -423,7 +423,7 @@ func (r *ClusterResourceSetReconciler) patchOwnerRefToResource(ctx context.Conte
 
 // clusterToClusterResourceSet is mapper function that maps clusters to ClusterResourceSet.
 func (r *ClusterResourceSetReconciler) clusterToClusterResourceSet(o client.Object) []ctrl.Request {
-	result := make([]ctrl.Request, 0)
+	result := []ctrl.Request{}
 
 	cluster, ok := o.(*clusterv1.Cluster)
 	if !ok {
@@ -461,7 +461,7 @@ func (r *ClusterResourceSetReconciler) clusterToClusterResourceSet(o client.Obje
 
 // resourceToClusterResourceSet is mapper function that maps resources to ClusterResourceSet.
 func (r *ClusterResourceSetReconciler) resourceToClusterResourceSet(o client.Object) []ctrl.Request {
-	result := make([]ctrl.Request, 0)
+	result := []ctrl.Request{}
 
 	// Add all ClusterResourceSet owners.
 	for _, owner := range o.GetOwnerReferences() {

--- a/exp/addons/internal/controllers/clusterresourceset_controller.go
+++ b/exp/addons/internal/controllers/clusterresourceset_controller.go
@@ -268,7 +268,6 @@ func (r *ClusterResourceSetReconciler) ApplyClusterResourceSet(ctx context.Conte
 	strategy := addonsv1.ClusterResourceSetStrategy(clusterResourceSet.Spec.Strategy)
 
 	for _, resource := range clusterResourceSet.Spec.Resources {
-
 		if resourceSetBinding.IsApplied(resource) && strategy == addonsv1.ClusterResourceSetStrategyApplyOnce {
 			continue
 		}
@@ -287,7 +286,17 @@ func (r *ClusterResourceSetReconciler) ApplyClusterResourceSet(ctx context.Conte
 		// We now retrieve the resource to compute the hash
 		unstructuredObj, err := r.getResource(ctx, resource, cluster.GetNamespace())
 		if err != nil {
-			handleGetResourceErrors(clusterResourceSet, err, errList)
+			if err == ErrSecretTypeNotSupported {
+				conditions.MarkFalse(clusterResourceSet, addonsv1.ResourcesAppliedCondition, addonsv1.WrongSecretTypeReason, clusterv1.ConditionSeverityWarning, err.Error())
+			} else {
+				conditions.MarkFalse(clusterResourceSet, addonsv1.ResourcesAppliedCondition, addonsv1.RetrievingResourceFailedReason, clusterv1.ConditionSeverityWarning, err.Error())
+
+				// Continue without adding the error to the aggregate if we can't find the resource.
+				if apierrors.IsNotFound(err) {
+					continue
+				}
+			}
+			errList = append(errList, err)
 			continue
 		}
 
@@ -316,7 +325,8 @@ func (r *ClusterResourceSetReconciler) ApplyClusterResourceSet(ctx context.Conte
 		}
 
 		// now calculate the new hash to compare with the old
-		dataList, newHash := getDataListAndHash(unstructuredObj.GetKind(), data.(map[string]interface{}), errList)
+		dataList, newHash, dataListAndHashErrList := getDataListAndHash(unstructuredObj.GetKind(), data.(map[string]interface{}))
+		errList = append(errList, dataListAndHashErrList...)
 
 		// This is where we determine if we continue the process or not.
 		if isAlreadyApplied && oldHash == newHash {

--- a/exp/addons/internal/controllers/clusterresourceset_controller.go
+++ b/exp/addons/internal/controllers/clusterresourceset_controller.go
@@ -309,7 +309,6 @@ func (r *ClusterResourceSetReconciler) ApplyClusterResourceSet(ctx context.Conte
 			errList = append(errList, err)
 		}
 
-		// Since maps are not ordered, we need to order them to get the same hash at each reconcile.
 		data, ok := unstructuredObj.UnstructuredContent()["data"]
 		if !ok {
 			errList = append(errList, errors.New("failed to get data field from the resource"))

--- a/exp/addons/internal/controllers/clusterresourceset_helpers.go
+++ b/exp/addons/internal/controllers/clusterresourceset_helpers.go
@@ -21,8 +21,10 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha256"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"unicode"
 
 	"github.com/pkg/errors"
@@ -37,6 +39,7 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	addonsv1 "sigs.k8s.io/cluster-api/exp/addons/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util"
+	"sigs.k8s.io/cluster-api/util/conditions"
 	utilresource "sigs.k8s.io/cluster-api/util/resource"
 	utilyaml "sigs.k8s.io/cluster-api/util/yaml"
 )
@@ -227,4 +230,47 @@ func computeHash(dataArr [][]byte) string {
 		}
 	}
 	return fmt.Sprintf("sha256:%x", hash.Sum(nil))
+}
+
+func getDataListAndHash(resourceKind string, unstructuredData map[string]interface{}, errList []error) ([][]byte, string) {
+	// Since maps are not ordered, we need to order them to get the same hash at each reconcile.
+	keys := make([]string, 0)
+
+	for key := range unstructuredData {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	dataList := make([][]byte, 0)
+	for _, key := range keys {
+		val, ok, err := unstructured.NestedString(unstructuredData, key)
+		if !ok || err != nil {
+			errList = append(errList, errors.New("failed to get value field from the resource"))
+			continue
+		}
+
+		byteArr := []byte(val)
+		// If the resource is a Secret, data needs to be decoded.
+		if resourceKind == string(addonsv1.SecretClusterResourceSetResourceKind) {
+			byteArr, _ = base64.StdEncoding.DecodeString(val)
+		}
+
+		dataList = append(dataList, byteArr)
+	}
+
+	return dataList, computeHash(dataList)
+}
+
+func handleGetResourceErrors(clusterResourceSet *addonsv1.ClusterResourceSet, err error, errList []error) {
+	if err == ErrSecretTypeNotSupported {
+		conditions.MarkFalse(clusterResourceSet, addonsv1.ResourcesAppliedCondition, addonsv1.WrongSecretTypeReason, clusterv1.ConditionSeverityWarning, err.Error())
+	} else {
+		conditions.MarkFalse(clusterResourceSet, addonsv1.ResourcesAppliedCondition, addonsv1.RetrievingResourceFailedReason, clusterv1.ConditionSeverityWarning, err.Error())
+
+		// Continue without adding the error to the aggregate if we can't find the resource.
+		if apierrors.IsNotFound(err) {
+			return
+		}
+	}
+	errList = append(errList, err)
 }

--- a/exp/addons/internal/controllers/clusterresourceset_helpers.go
+++ b/exp/addons/internal/controllers/clusterresourceset_helpers.go
@@ -233,14 +233,14 @@ func computeHash(dataArr [][]byte) string {
 
 func getDataListAndHash(resourceKind string, unstructuredData map[string]interface{}) ([][]byte, string, []error) {
 	// Since maps are not ordered, we need to order them to get the same hash at each reconcile.
-	keys := make([]string, 0)
+	keys := []string{}
 
 	for key := range unstructuredData {
 		keys = append(keys, key)
 	}
 	sort.Strings(keys)
 
-	dataList := make([][]byte, 0)
+	dataList := [][]byte{}
 	errList := []error{}
 	for _, key := range keys {
 		val, ok, err := unstructured.NestedString(unstructuredData, key)


### PR DESCRIPTION
Previously, the error list was passed to functions as a slice. The
functions used 'append' to add an error to the slice, but 'append'
creates a new slice, and the caller did not see this update.

The caller did not see the update because the functions did neither of
these:
(a) Return the new slice to the caller
(b) Change the caller's reference to the slice to point to the new
slice.

See https://go.dev/play/p/dTWLE_46Hv7 for a concise example of the bug.