### PR TITLE
feat: Add support for compressed resources to the CRS controller

### DIFF
--- a/exp/addons/api/v1beta1/clusterresourceset_types.go
+++ b/exp/addons/api/v1beta1/clusterresourceset_types.go
@@ -29,6 +29,9 @@ const (
 
 	// ClusterResourceSetFinalizer is added to the ClusterResourceSet object for additional cleanup logic on deletion.
 	ClusterResourceSetFinalizer = "addons.cluster.x-k8s.io"
+
+	// ClusterResourceSetCompressedAnnotation is added to a Secret or ConfigMap with compressed data.
+	ClusterResourceSetCompressedAnnotation = "addons.cluster.x-k8s.io/resource-set-compressed"
 )
 
 // ANCHOR: ClusterResourceSetSpec

--- a/exp/addons/util/data.go
+++ b/exp/addons/util/data.go
@@ -1,0 +1,169 @@
+package util
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	addonsv1 "sigs.k8s.io/cluster-api/exp/addons/api/v1beta1"
+)
+
+func IsCompressed(src *unstructured.Unstructured) bool {
+	annotations := src.GetAnnotations()
+	av, ok := annotations[addonsv1.ClusterResourceSetCompressedAnnotation]
+	if !ok {
+		return false
+	}
+	return av == "true"
+}
+
+func Compress(src *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+	var field string
+	switch kind := src.GetKind(); kind {
+	case string(addonsv1.ConfigMapClusterResourceSetResourceKind):
+		field = "binaryData"
+	case string(addonsv1.SecretClusterResourceSetResourceKind):
+		field = "data"
+	default:
+		return nil, fmt.Errorf("resource kind is %q, must be ConfigMap or Secret", kind)
+	}
+
+	dst := src.DeepCopy()
+	if IsCompressed(src) {
+		return dst, nil
+	}
+
+	dataCopy, ok, err := unstructured.NestedStringMap(src.UnstructuredContent(), field)
+	if err != nil {
+		return nil, fmt.Errorf("reading data from field %q: %w", field, err)
+	}
+	if !ok {
+		return nil, fmt.Errorf("field %q not found", field)
+	}
+
+	for key := range dataCopy {
+		cv, err := compressValue(dataCopy[key])
+		if err != nil {
+			return nil, fmt.Errorf("compressing key %q value: %w", key, err)
+		}
+		dataCopy[key] = cv
+	}
+
+	if err := unstructured.SetNestedStringMap(dst.UnstructuredContent(), dataCopy, field); err != nil {
+		return nil, fmt.Errorf("writing compressed data: %w", err)
+	}
+
+	annotations := dst.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+	annotations[addonsv1.ClusterResourceSetCompressedAnnotation] = "true"
+	dst.SetAnnotations(annotations)
+
+	return dst, nil
+}
+
+func Decompress(src *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+	var field string
+	switch kind := src.GetKind(); kind {
+	case string(addonsv1.ConfigMapClusterResourceSetResourceKind):
+		field = "binaryData"
+	case string(addonsv1.SecretClusterResourceSetResourceKind):
+		field = "data"
+	default:
+		return nil, fmt.Errorf("resource kind is %q, must be ConfigMap or Secret", kind)
+	}
+
+	dst := src.DeepCopy()
+	if !IsCompressed(src) {
+		return dst, nil
+	}
+
+	dataCopy, ok, err := unstructured.NestedMap(src.UnstructuredContent(), field)
+	if err != nil {
+		return nil, fmt.Errorf("reading data from field %q: %w", field, err)
+	}
+	if !ok {
+		return nil, fmt.Errorf("field %q not found", field)
+	}
+
+	for key := range dataCopy {
+		cv, ok := dataCopy[key].([]byte)
+		if !ok {
+			return nil, fmt.Errorf("reading key %q value: %w", key, err)
+		}
+		v, err := decompressValue(cv)
+		if err != nil {
+			return nil, fmt.Errorf("decompressing key %q value: %w", key, err)
+		}
+		dataCopy[key] = v
+	}
+
+	if err := unstructured.SetNestedMap(dst.UnstructuredContent(), dataCopy, field); err != nil {
+		return nil, fmt.Errorf("writing decompressed data: %w", err)
+	}
+
+	annotations := dst.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+	annotations[addonsv1.ClusterResourceSetCompressedAnnotation] = "false"
+	dst.SetAnnotations(annotations)
+
+	return dst, nil
+}
+
+// compressValue takes a value that is base64-encoded. It base64-decodes this value, zips it, base64-encodes it again,
+// and finally returns it.
+func compressValue(v string) (string, error) {
+	src := strings.NewReader(v)
+	b64r := base64.NewDecoder(base64.StdEncoding, src)
+
+	var dst bytes.Buffer
+	b64w := base64.NewEncoder(base64.StdEncoding, &dst)
+	zw := gzip.NewWriter(b64w)
+
+	if _, err := io.Copy(zw, b64r); err != nil {
+		return "", err
+	}
+	// Flush any partially written blocks.
+	if err := zw.Close(); err != nil {
+		return "", err
+	}
+	if err := b64w.Close(); err != nil {
+		return "", err
+	}
+
+	return dst.String(), nil
+}
+
+// decompressValue takes a value that is zipped and base64-encoded (in that order). It base64-decodes this value, unzips
+// it, base64-encodes it again, and finally returns it.
+func decompressValue(v []byte) ([]byte, error) {
+	src := bytes.NewReader(v)
+	b64r := base64.NewDecoder(base64.StdEncoding, src)
+	zr, err := gzip.NewReader(b64r)
+	if err != nil {
+		return nil, err
+	}
+
+	var dst bytes.Buffer
+	zw := base64.NewEncoder(base64.StdEncoding, &dst)
+
+	if _, err := io.Copy(zw, zr); err != nil {
+		return nil, err
+	}
+	if err := zw.Close(); err != nil {
+		return nil, err
+	}
+	if err := zr.Close(); err != nil {
+		return nil, err
+	}
+
+	return dst.Bytes(), nil
+}

--- a/exp/addons/util/data_test.go
+++ b/exp/addons/util/data_test.go
@@ -1,0 +1,120 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	addonsv1 "sigs.k8s.io/cluster-api/exp/addons/api/v1beta1"
+)
+
+func TestCompress(t *testing.T) {
+	tests := []struct {
+		name        string
+		obj         *unstructured.Unstructured
+		wantDataKey string
+		wantData    map[string]string
+		wantErr     bool
+	}{
+		{
+			name: "compress ConfigMap",
+			obj: fakeObj(t, "ConfigMap", map[string]string{
+				"key": "value",
+			}),
+			wantDataKey: "binaryData",
+			wantData: map[string]string{
+				"key": "H4sIAAAAAAAA/ypLzClNBQQAAP//NFh3HQUAAAA=",
+			},
+		},
+		{
+			name: "compress Secret",
+			obj: fakeObj(t, "Secret", map[string]string{
+				"key": "value",
+			}),
+			wantDataKey: "data",
+			wantData: map[string]string{
+				"key": "H4sIAAAAAAAA/ypLzClNBQQAAP//NFh3HQUAAAA=",
+			},
+		},
+		{
+			name: "fail to compress unknown kind",
+			obj: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": "Foobar",
+				},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Compress(tt.obj)
+			assert.Equal(t, tt.wantErr, err != nil, "error %s", err)
+
+			if tt.wantErr {
+				return
+			}
+
+			// Check the data, if necessary
+			gotData, ok, err := unstructured.NestedStringMap(got.UnstructuredContent(), tt.wantDataKey)
+			assert.True(t, ok)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.wantData, gotData)
+
+			// Verify that Compress is idempotent
+			got2, err := Compress(got)
+			assert.NoError(t, err)
+			assert.Equal(t, got, got2)
+		})
+	}
+}
+
+func fakeObj(t *testing.T, kind string, data map[string]string) *unstructured.Unstructured {
+	t.Helper()
+
+	binaryData := make(map[string][]byte, len(data))
+	for k := range data {
+		binaryData[k] = []byte(data[k])
+	}
+
+	var tmp runtime.Object
+	switch kind {
+	case string(addonsv1.ConfigMapClusterResourceSetResourceKind):
+		tmp = &corev1.ConfigMap{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "ConfigMap",
+				APIVersion: "v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "example",
+				Namespace: "default",
+			},
+			BinaryData: binaryData,
+		}
+	case string(addonsv1.SecretClusterResourceSetResourceKind):
+		tmp = &corev1.Secret{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Secret",
+				APIVersion: "v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "example",
+				Namespace: "default",
+			},
+			Data: binaryData,
+		}
+	default:
+		t.Fatalf("unknown kind %s", kind)
+	}
+	c := fake.NewClientBuilder().Build()
+	obj := &unstructured.Unstructured{}
+	if err := c.Scheme().Convert(tmp, obj, nil); err != nil {
+		t.Fatalf("converting input to unstructured: %s", err)
+	}
+	return obj
+}


### PR DESCRIPTION
ClusterResourceSet resources are embedded in ConfigMaps and Secrets. The default etcd maximum object size is 1024KB, which limits all Kubernetes resources to approximately that size. We've seen some resources, like the [Tigera Operator manifest](https://projectcalico.docs.tigera.io/archive/v3.24/manifests/tigera-operator.yaml), exceed this size.

Gzip compression is very effective at reducing the size of the embedded resource. For example, the Tigera Operator manifest:

```
1268K tigera-operator-configmap.yaml
136K   tigera-operator-configmap-gz+b64.yaml
```

To use compressed resources, the user should
1. gzip and base64-encode the values in the `data` (Secret) or `binaryData` (ConfigMap) fields
2. Add the `addons.cluster.x-k8s.io/resource-set-compressed=true` annotation to the Secret or ConfigMap.

The PR adds a library that consumers of the `sig.sk8s.io/cluster-api` go module can use to compress a Secret or ConfigMap.