### PR TITLE
Apply all patches from v1.1.3 into v1.2.2

### DIFF
--- a/config/crd/bases/addons.cluster.x-k8s.io_clusterresourcesets.yaml
+++ b/config/crd/bases/addons.cluster.x-k8s.io_clusterresourcesets.yaml
@@ -438,6 +438,7 @@ spec:
                   Defaults to ApplyOnce. This field is immutable.
                 enum:
                 - ApplyOnce
+                - ApplyAlways
                 type: string
             required:
             - clusterSelector

--- a/config/crd/bases/addons.cluster.x-k8s.io_clusterresourcesets.yaml
+++ b/config/crd/bases/addons.cluster.x-k8s.io_clusterresourcesets.yaml
@@ -112,6 +112,7 @@ spec:
                   Defaults to ApplyOnce. This field is immutable.
                 enum:
                 - ApplyOnce
+                - ApplyAlways
                 type: string
             required:
             - clusterSelector

--- a/exp/addons/api/v1beta1/clusterresourceset_types.go
+++ b/exp/addons/api/v1beta1/clusterresourceset_types.go
@@ -46,7 +46,7 @@ type ClusterResourceSetSpec struct {
 	Resources []ResourceRef `json:"resources,omitempty"`
 
 	// Strategy is the strategy to be used during applying resources. Defaults to ApplyOnce. This field is immutable.
-	// +kubebuilder:validation:Enum=ApplyOnce
+	// +kubebuilder:validation:Enum=ApplyOnce;ApplyAlways
 	// +optional
 	Strategy string `json:"strategy,omitempty"`
 }
@@ -80,6 +80,9 @@ const (
 	// ClusterResourceSetStrategyApplyOnce is the default strategy a ClusterResourceSet strategy is assigned by
 	// ClusterResourceSet controller after being created if not specified by user.
 	ClusterResourceSetStrategyApplyOnce ClusterResourceSetStrategy = "ApplyOnce"
+	// ClusterResourceSetStrategyApplyAlways is the strategy where changes to the ClusterResourceSet
+	// are applied always if they exist already in clusters or created if they do not.
+	ClusterResourceSetStrategyApplyAlways ClusterResourceSetStrategy = "ApplyAlways"
 )
 
 // SetTypedStrategy sets the Strategy field to the string representation of ClusterResourceSetStrategy.

--- a/exp/addons/api/v1beta1/clusterresourcesetbinding_types.go
+++ b/exp/addons/api/v1beta1/clusterresourcesetbinding_types.go
@@ -80,6 +80,16 @@ func (r *ResourceSetBinding) SetBinding(resourceBinding ResourceBinding) {
 	r.Resources = append(r.Resources, resourceBinding)
 }
 
+// GetBinding returns a copy of the binding whose reference matches resourceRef, or nil if no binding matches.
+func (r *ResourceSetBinding) GetBinding(resourceRef ResourceRef) *ResourceBinding {
+	for i := range r.Resources {
+		if reflect.DeepEqual(r.Resources[i].ResourceRef, resourceRef) {
+			return r.Resources[i].DeepCopy()
+		}
+	}
+	return nil
+}
+
 // GetOrCreateBinding returns the ResourceSetBinding for a given ClusterResourceSet if exists,
 // otherwise creates one and updates ClusterResourceSet with it.
 func (c *ClusterResourceSetBinding) GetOrCreateBinding(clusterResourceSet *ClusterResourceSet) *ResourceSetBinding {

--- a/exp/addons/api/v1beta1/clusterresourcesetbinding_types_test.go
+++ b/exp/addons/api/v1beta1/clusterresourcesetbinding_types_test.go
@@ -156,3 +156,57 @@ func TestSetResourceBinding(t *testing.T) {
 		})
 	}
 }
+
+func TestGetResourceBinding(t *testing.T) {
+	tests := []struct {
+		name                string
+		resourceSetBinding  ResourceSetBinding
+		resourceRef         ResourceRef
+		wantResourceBinding *ResourceBinding
+	}{
+		{
+			name: "should return the resourceBinding that matches the ref",
+			resourceSetBinding: ResourceSetBinding{
+				ClusterResourceSetName: "test-clusterResourceSet",
+				Resources: []ResourceBinding{
+					{
+						ResourceRef: ResourceRef{
+							Name: "test-configMap",
+							Kind: "ConfigMap",
+						},
+					},
+				},
+			},
+			resourceRef: ResourceRef{
+				Name: "test-configMap",
+				Kind: "ConfigMap",
+			},
+			wantResourceBinding: &ResourceBinding{
+				ResourceRef: ResourceRef{
+					Name: "test-configMap",
+					Kind: "ConfigMap",
+				},
+			},
+		},
+		{
+			name: "should return nil if no resourceBinding matches the ref",
+			resourceSetBinding: ResourceSetBinding{
+				ClusterResourceSetName: "test-clusterResourceSet",
+				Resources:              []ResourceBinding{},
+			},
+			resourceRef: ResourceRef{
+				Name: "test-configMap",
+				Kind: "ConfigMap",
+			},
+			wantResourceBinding: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gs := NewWithT(t)
+			binding := tt.resourceSetBinding.GetBinding(tt.resourceRef)
+			gs.Expect(tt.wantResourceBinding).To(BeEquivalentTo(binding))
+		})
+	}
+}

--- a/exp/addons/internal/controllers/clusterresourceset_controller.go
+++ b/exp/addons/internal/controllers/clusterresourceset_controller.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"reflect"
 	"sort"
 	"time"
 
@@ -283,7 +282,8 @@ func (r *ClusterResourceSetReconciler) ApplyClusterResourceSet(ctx context.Conte
 		// we now will rely on the hash to know when to make changes
 		if isAlreadyApplied {
 			log.Info("the resource has already been applied, checking if we should reapply or not based on hash", "Resource kind", resource.Kind, "Resource name", resource.Name)
-			oldHash = getPreviousHash(resource, resourceSetBinding.Resources)
+			binding := resourceSetBinding.GetBinding(resource)
+			oldHash = binding.Hash
 		}
 
 		// We now retrieve the resource to compute the hash
@@ -537,22 +537,4 @@ func handleGetResourceErrors(clusterResourceSet *addonsv1.ClusterResourceSet, er
 		}
 	}
 	errList = append(errList, err)
-}
-
-func getPreviousHash(resourceRef addonsv1.ResourceRef, resources []addonsv1.ResourceBinding) string {
-	var oldHash string
-	if len(resources) != 0 {
-		var previouseBinding *addonsv1.ResourceBinding
-		for _, rb := range resources {
-			if reflect.DeepEqual(rb.ResourceRef, resourceRef) {
-				previouseBinding = &rb
-				break
-			}
-		}
-		if previouseBinding != nil {
-			oldHash = previouseBinding.Hash
-		}
-	}
-
-	return oldHash
 }

--- a/exp/addons/internal/controllers/clusterresourceset_controller.go
+++ b/exp/addons/internal/controllers/clusterresourceset_controller.go
@@ -267,7 +267,6 @@ func (r *ClusterResourceSetReconciler) ApplyClusterResourceSet(ctx context.Conte
 
 	// Iterate all resources and apply them to the cluster and update the resource status in the ClusterResourceSetBinding object.
 	for _, resource := range clusterResourceSet.Spec.Resources {
-
 		strategy := addonsv1.ClusterResourceSetStrategy(clusterResourceSet.Spec.Strategy)
 
 		// If resource is already applied successfully and clusterResourceSet mode is "ApplyOnce", continue. (No need to check hash changes here)

--- a/exp/addons/internal/controllers/clusterresourceset_controller.go
+++ b/exp/addons/internal/controllers/clusterresourceset_controller.go
@@ -77,6 +77,7 @@ func (r *ClusterResourceSetReconciler) SetupWithManager(ctx context.Context, mgr
 		Watches(
 			&source.Kind{Type: &corev1.ConfigMap{}},
 			handler.EnqueueRequestsFromMapFunc(r.resourceToClusterResourceSet),
+			builder.OnlyMetadata,
 			builder.WithPredicates(
 				resourcepredicates.ResourceCreateUpdate(ctrl.LoggerFrom(ctx)),
 			),
@@ -84,6 +85,7 @@ func (r *ClusterResourceSetReconciler) SetupWithManager(ctx context.Context, mgr
 		Watches(
 			&source.Kind{Type: &corev1.Secret{}},
 			handler.EnqueueRequestsFromMapFunc(r.resourceToClusterResourceSet),
+			builder.OnlyMetadata,
 			builder.WithPredicates(
 				resourcepredicates.ResourceCreateUpdate(ctrl.LoggerFrom(ctx)),
 			),

--- a/exp/addons/internal/controllers/clusterresourceset_controller.go
+++ b/exp/addons/internal/controllers/clusterresourceset_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"reflect"
 	"sort"
 	"time"
 
@@ -265,39 +266,45 @@ func (r *ClusterResourceSetReconciler) ApplyClusterResourceSet(ctx context.Conte
 	errList := []error{}
 	resourceSetBinding := clusterResourceSetBinding.GetOrCreateBinding(clusterResourceSet)
 
-	// Iterate all resources and apply them to the cluster and update the resource status in the ClusterResourceSetBinding object.
-	for _, resource := range clusterResourceSet.Spec.Resources {
-		strategy := addonsv1.ClusterResourceSetStrategy(clusterResourceSet.Spec.Strategy)
+	// The behavior depends on what type of strategy has been applied.
 
-		// If resource is already applied successfully and clusterResourceSet mode is "ApplyOnce", continue. (No need to check hash changes here)
+	strategy := addonsv1.ClusterResourceSetStrategy(clusterResourceSet.Spec.Strategy)
+
+	for _, resource := range clusterResourceSet.Spec.Resources {
+
 		if resourceSetBinding.IsApplied(resource) && strategy == addonsv1.ClusterResourceSetStrategyApplyOnce {
 			continue
 		}
 
+		// here we may have applied already the resource, so the logic should be slightly different
+		var oldHash string
+		isAlreadyApplied := resourceSetBinding.IsApplied(resource)
+
+		// This resource was applied once already and it is not the strategy applyonce
+		// we now will rely on the hash to know when to make changes
+		if isAlreadyApplied {
+			log.Info("the resource has already been applied, checking if we should reapply or not based on hash", "Resource kind", resource.Kind, "Resource name", resource.Name)
+			oldHash = getPreviousHash(resource, resourceSetBinding.Resources)
+		}
+
+		// We now retrieve the resource to compute the hash
 		unstructuredObj, err := r.getResource(ctx, resource, cluster.GetNamespace())
 		if err != nil {
-			if err == ErrSecretTypeNotSupported {
-				conditions.MarkFalse(clusterResourceSet, addonsv1.ResourcesAppliedCondition, addonsv1.WrongSecretTypeReason, clusterv1.ConditionSeverityWarning, err.Error())
-			} else {
-				conditions.MarkFalse(clusterResourceSet, addonsv1.ResourcesAppliedCondition, addonsv1.RetrievingResourceFailedReason, clusterv1.ConditionSeverityWarning, err.Error())
-
-				// Continue without adding the error to the aggregate if we can't find the resource.
-				if apierrors.IsNotFound(err) {
-					continue
-				}
-			}
-			errList = append(errList, err)
+			handleGetResourceErrors(clusterResourceSet, err, errList)
 			continue
 		}
 
-		// Set status in ClusterResourceSetBinding in case of early continue due to a failure.
-		// Set only when resource is retrieved successfully.
-		resourceSetBinding.SetBinding(addonsv1.ResourceBinding{
-			ResourceRef:     resource,
-			Hash:            "",
-			Applied:         false,
-			LastAppliedTime: &metav1.Time{Time: time.Now().UTC()},
-		})
+		// if we have not already applied the resource in the past create a placeholder status
+		if !isAlreadyApplied {
+			// Set status in ClusterResourceSetBinding in case of early continue due to a failure.
+			// Set only when resource is retrieved successfully.
+			resourceSetBinding.SetBinding(addonsv1.ResourceBinding{
+				ResourceRef:     resource,
+				Hash:            "",
+				Applied:         false,
+				LastAppliedTime: &metav1.Time{Time: time.Now().UTC()},
+			})
+		}
 
 		if err := r.patchOwnerRefToResource(ctx, clusterResourceSet, unstructuredObj); err != nil {
 			log.Error(err, "Failed to patch ClusterResourceSet as resource owner reference",
@@ -306,34 +313,20 @@ func (r *ClusterResourceSetReconciler) ApplyClusterResourceSet(ctx context.Conte
 		}
 
 		// Since maps are not ordered, we need to order them to get the same hash at each reconcile.
-		keys := make([]string, 0)
 		data, ok := unstructuredObj.UnstructuredContent()["data"]
 		if !ok {
 			errList = append(errList, errors.New("failed to get data field from the resource"))
 			continue
 		}
 
-		unstructuredData := data.(map[string]interface{})
-		for key := range unstructuredData {
-			keys = append(keys, key)
-		}
-		sort.Strings(keys)
+		// now calculate the new hash to compare with the old
+		dataList, newHash := getDataListAndHash(unstructuredObj.GetKind(), data.(map[string]interface{}), errList)
 
-		dataList := make([][]byte, 0)
-		for _, key := range keys {
-			val, ok, err := unstructured.NestedString(unstructuredData, key)
-			if !ok || err != nil {
-				errList = append(errList, errors.New("failed to get value field from the resource"))
-				continue
-			}
-
-			byteArr := []byte(val)
-			// If the resource is a Secret, data needs to be decoded.
-			if unstructuredObj.GetKind() == string(addonsv1.SecretClusterResourceSetResourceKind) {
-				byteArr, _ = base64.StdEncoding.DecodeString(val)
-			}
-
-			dataList = append(dataList, byteArr)
+		// This is where we determine if we continue the process or not.
+		if isAlreadyApplied && oldHash == newHash {
+			log.Info("the resource has already been applied and data is identical, no need to re-apply, moving on to next resource", "Resource kind", resource.Kind, "Resource name", resource.Name)
+			// if we have the same has, move on to the next resource
+			continue
 		}
 
 		// Apply all values in the key-value pair of the resource to the cluster.
@@ -352,11 +345,12 @@ func (r *ClusterResourceSetReconciler) ApplyClusterResourceSet(ctx context.Conte
 
 		resourceSetBinding.SetBinding(addonsv1.ResourceBinding{
 			ResourceRef:     resource,
-			Hash:            computeHash(dataList),
+			Hash:            newHash,
 			Applied:         isSuccessful,
 			LastAppliedTime: &metav1.Time{Time: time.Now().UTC()},
 		})
 	}
+
 	if len(errList) > 0 {
 		return kerrors.NewAggregate(errList)
 	}
@@ -501,4 +495,65 @@ func (r *ClusterResourceSetReconciler) resourceToClusterResourceSet(o client.Obj
 	}
 
 	return result
+}
+
+func getDataListAndHash(resourceKind string, unstructuredData map[string]interface{}, errList []error) ([][]byte, string) {
+	// Since maps are not ordered, we need to order them to get the same hash at each reconcile.
+	keys := make([]string, 0)
+
+	for key := range unstructuredData {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	dataList := make([][]byte, 0)
+	for _, key := range keys {
+		val, ok, err := unstructured.NestedString(unstructuredData, key)
+		if !ok || err != nil {
+			errList = append(errList, errors.New("failed to get value field from the resource"))
+			continue
+		}
+
+		byteArr := []byte(val)
+		// If the resource is a Secret, data needs to be decoded.
+		if resourceKind == string(addonsv1.SecretClusterResourceSetResourceKind) {
+			byteArr, _ = base64.StdEncoding.DecodeString(val)
+		}
+
+		dataList = append(dataList, byteArr)
+	}
+
+	return dataList, computeHash(dataList)
+}
+
+func handleGetResourceErrors(clusterResourceSet *addonsv1.ClusterResourceSet, err error, errList []error) {
+	if err == ErrSecretTypeNotSupported {
+		conditions.MarkFalse(clusterResourceSet, addonsv1.ResourcesAppliedCondition, addonsv1.WrongSecretTypeReason, clusterv1.ConditionSeverityWarning, err.Error())
+	} else {
+		conditions.MarkFalse(clusterResourceSet, addonsv1.ResourcesAppliedCondition, addonsv1.RetrievingResourceFailedReason, clusterv1.ConditionSeverityWarning, err.Error())
+
+		// Continue without adding the error to the aggregate if we can't find the resource.
+		if apierrors.IsNotFound(err) {
+			return
+		}
+	}
+	errList = append(errList, err)
+}
+
+func getPreviousHash(resourceRef addonsv1.ResourceRef, resources []addonsv1.ResourceBinding) string {
+	var oldHash string
+	if len(resources) != 0 {
+		var previouseBinding *addonsv1.ResourceBinding
+		for _, rb := range resources {
+			if reflect.DeepEqual(rb.ResourceRef, resourceRef) {
+				previouseBinding = &rb
+				break
+			}
+		}
+		if previouseBinding != nil {
+			oldHash = previouseBinding.Hash
+		}
+	}
+
+	return oldHash
 }

--- a/exp/addons/internal/controllers/clusterresourceset_controller.go
+++ b/exp/addons/internal/controllers/clusterresourceset_controller.go
@@ -50,10 +50,8 @@ import (
 	"sigs.k8s.io/cluster-api/util/predicates"
 )
 
-var (
-	// ErrSecretTypeNotSupported signals that a Secret is not supported.
-	ErrSecretTypeNotSupported = errors.New("unsupported secret type")
-)
+// ErrSecretTypeNotSupported signals that a Secret is not supported.
+var ErrSecretTypeNotSupported = errors.New("unsupported secret type")
 
 // +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;patch
 // +kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch;patch
@@ -79,23 +77,20 @@ func (r *ClusterResourceSetReconciler) SetupWithManager(ctx context.Context, mgr
 		Watches(
 			&source.Kind{Type: &corev1.ConfigMap{}},
 			handler.EnqueueRequestsFromMapFunc(r.resourceToClusterResourceSet),
-			builder.OnlyMetadata,
 			builder.WithPredicates(
-				resourcepredicates.ResourceCreate(ctrl.LoggerFrom(ctx)),
+				resourcepredicates.ResourceCreateUpdate(ctrl.LoggerFrom(ctx)),
 			),
 		).
 		Watches(
 			&source.Kind{Type: &corev1.Secret{}},
 			handler.EnqueueRequestsFromMapFunc(r.resourceToClusterResourceSet),
-			builder.OnlyMetadata,
 			builder.WithPredicates(
-				resourcepredicates.ResourceCreate(ctrl.LoggerFrom(ctx)),
+				resourcepredicates.ResourceCreateUpdate(ctrl.LoggerFrom(ctx)),
 			),
 		).
 		WithOptions(options).
 		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue)).
 		Complete(r)
-
 	if err != nil {
 		return errors.Wrap(err, "failed setting up with a controller manager")
 	}
@@ -220,7 +215,7 @@ func (r *ClusterResourceSetReconciler) getClustersByClusterResourceSetSelector(c
 		return nil, errors.Wrap(err, "failed to list clusters")
 	}
 
-	clusters := []*clusterv1.Cluster{}
+	clusters := make([]*clusterv1.Cluster, 0)
 	for i := range clusterList.Items {
 		c := &clusterList.Items[i]
 		if c.DeletionTimestamp.IsZero() {
@@ -270,8 +265,11 @@ func (r *ClusterResourceSetReconciler) ApplyClusterResourceSet(ctx context.Conte
 
 	// Iterate all resources and apply them to the cluster and update the resource status in the ClusterResourceSetBinding object.
 	for _, resource := range clusterResourceSet.Spec.Resources {
+
+		strategy := addonsv1.ClusterResourceSetStrategy(clusterResourceSet.Spec.Strategy)
+
 		// If resource is already applied successfully and clusterResourceSet mode is "ApplyOnce", continue. (No need to check hash changes here)
-		if resourceSetBinding.IsApplied(resource) {
+		if resourceSetBinding.IsApplied(resource) && strategy == addonsv1.ClusterResourceSetStrategyApplyOnce {
 			continue
 		}
 
@@ -343,7 +341,7 @@ func (r *ClusterResourceSetReconciler) ApplyClusterResourceSet(ctx context.Conte
 		for i := range dataList {
 			data := dataList[i]
 
-			if err := apply(ctx, remoteClient, data); err != nil {
+			if err := apply(ctx, remoteClient, strategy, data); err != nil {
 				isSuccessful = false
 				log.Error(err, "failed to apply ClusterResourceSet resource", "Resource kind", resource.Kind, "Resource name", resource.Name)
 				conditions.MarkFalse(clusterResourceSet, addonsv1.ResourcesAppliedCondition, addonsv1.ApplyFailedReason, clusterv1.ConditionSeverityWarning, err.Error())
@@ -424,7 +422,7 @@ func (r *ClusterResourceSetReconciler) patchOwnerRefToResource(ctx context.Conte
 
 // clusterToClusterResourceSet is mapper function that maps clusters to ClusterResourceSet.
 func (r *ClusterResourceSetReconciler) clusterToClusterResourceSet(o client.Object) []ctrl.Request {
-	result := []ctrl.Request{}
+	result := make([]ctrl.Request, 0)
 
 	cluster, ok := o.(*clusterv1.Cluster)
 	if !ok {
@@ -462,7 +460,7 @@ func (r *ClusterResourceSetReconciler) clusterToClusterResourceSet(o client.Obje
 
 // resourceToClusterResourceSet is mapper function that maps resources to ClusterResourceSet.
 func (r *ClusterResourceSetReconciler) resourceToClusterResourceSet(o client.Object) []ctrl.Request {
-	result := []ctrl.Request{}
+	result := make([]ctrl.Request, 0)
 
 	// Add all ClusterResourceSet owners.
 	for _, owner := range o.GetOwnerReferences() {

--- a/exp/addons/internal/controllers/clusterresourceset_controller.go
+++ b/exp/addons/internal/controllers/clusterresourceset_controller.go
@@ -275,7 +275,6 @@ func (r *ClusterResourceSetReconciler) ApplyClusterResourceSet(ctx context.Conte
 		if resourceSetBinding.IsApplied(resource) && strategy == addonsv1.ClusterResourceSetStrategyApplyOnce {
 			continue
 		}
-
 		// here we may have applied already the resource, so the logic should be slightly different
 		var oldHash string
 		isAlreadyApplied := resourceSetBinding.IsApplied(resource)

--- a/exp/addons/internal/controllers/clusterresourceset_controller_test.go
+++ b/exp/addons/internal/controllers/clusterresourceset_controller_test.go
@@ -390,10 +390,6 @@ metadata:
 		testCluster.SetLabels(labels)
 		g.Expect(env.Update(ctx, testCluster)).To(Succeed())
 
-		// Must sleep here to make sure resource is created after the previous reconcile.
-		// If the resource is created in between, predicates are not used as intended in this test.
-		time.Sleep(2 * time.Second)
-
 		t.Log("Verifying ClusterResourceSetBinding is created with cluster owner reference")
 		// Wait until ClusterResourceSetBinding is created for the Cluster
 		clusterResourceSetBindingKey := client.ObjectKey{
@@ -419,6 +415,10 @@ metadata:
 			}
 			return false
 		}, timeout).Should(BeTrue())
+
+		// Must sleep here to make sure resource is created after the previous reconcile.
+		// If the resource is created in between, predicates are not used as intended in this test.
+		time.Sleep(2 * time.Second)
 
 		newSecret := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{

--- a/exp/addons/internal/controllers/clusterresourceset_controller_test.go
+++ b/exp/addons/internal/controllers/clusterresourceset_controller_test.go
@@ -862,7 +862,7 @@ data:
 		// value is unlikely to change. Our test below compares the lastAppliedTime values of two reconciles, so we wait
 		// to prevent the reconciles from running within the same second. Related issue: https://issues.k8s.io/15262
 		t.Log("Letting some time pass before updating the resource, so that lastAppliedTime will be different.")
-		time.Sleep(10 * time.Second)
+		time.Sleep(2 * time.Second)
 
 		// update the configmap data
 		t.Log("Updating the configmap resource")
@@ -953,7 +953,7 @@ data:
 		// value is unlikely to change. Our test below compares the lastAppliedTime values of two reconciles, so we wait
 		// to prevent the reconciles from running within the same second. Related issue: https://issues.k8s.io/15262
 		t.Log("Letting some time pass before updating the resource, so that lastAppliedTime will be different.")
-		time.Sleep(10 * time.Second)
+		time.Sleep(2 * time.Second)
 
 		// update the secrete, but not its data
 		t.Log("Updating the secret resource")

--- a/exp/addons/internal/controllers/clusterresourceset_controller_test.go
+++ b/exp/addons/internal/controllers/clusterresourceset_controller_test.go
@@ -768,7 +768,7 @@ data:
 			},
 		}
 
-		// update the configmap data
+		// update the secret data
 		t.Log("Updating the secret resource")
 		g.Expect(env.Update(ctx, secretUpdate)).To(Succeed())
 
@@ -789,6 +789,188 @@ data:
 			// only one resource is applied
 			resource := bindings[0].Resources[0]
 			return resource.Hash != oldHash
+		}, timeout).Should(BeTrue())
+	})
+
+	t.Run("Should create ClusterResourceSet with strategy 'AlwaysApply' and reconcile configmap only once if data has not changed", func(t *testing.T) {
+		g := NewWithT(t)
+		ns := setup(t, g)
+		defer teardown(t, g, ns)
+
+		t.Log("Updating the cluster with labels")
+		testCluster.SetLabels(labels)
+		g.Expect(env.Update(ctx, testCluster)).To(Succeed())
+
+		clusterResourceSetInstance := &addonsv1.ClusterResourceSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      clusterResourceSetName,
+				Namespace: ns.Name,
+			},
+			Spec: addonsv1.ClusterResourceSetSpec{
+				ClusterSelector: metav1.LabelSelector{
+					MatchLabels: labels,
+				},
+				Strategy:  "ApplyAlways",
+				Resources: []addonsv1.ResourceRef{{Name: configmapName, Kind: "ConfigMap"}},
+			},
+		}
+		// Create the ClusterResourceSet.
+		g.Expect(env.Create(ctx, clusterResourceSetInstance)).To(Succeed())
+
+		// Wait until ClusterResourceSetBinding is created for the Cluster
+		clusterResourceSetBindingKey := client.ObjectKey{
+			Namespace: testCluster.Namespace,
+			Name:      testCluster.Name,
+		}
+
+		// Wait until ClusterResourceSetBinding is created for the Cluster
+		t.Log("Waiting for the ClusterResourceSetBinding to be created")
+		oldHash := ""
+		var oldLastAppliedTime *metav1.Time
+		g.Eventually(func() bool {
+			binding := &addonsv1.ClusterResourceSetBinding{}
+			err := env.Get(ctx, clusterResourceSetBindingKey, binding)
+			if err != nil {
+				return false
+			}
+
+			bindings := binding.Spec.Bindings
+			// should only have one binding
+			if len(bindings) != 1 {
+				return false
+			}
+
+			// only one resource is applied
+			resource := bindings[0].Resources[0]
+			oldHash = resource.Hash
+			oldLastAppliedTime = resource.LastAppliedTime
+			return resource.Applied
+		}, timeout).Should(BeTrue())
+
+		// Get configmap obj, update the configmap
+		cmKey := client.ObjectKey{
+			Namespace: ns.Name,
+			Name:      configmapName,
+		}
+		cm := &corev1.ConfigMap{}
+		g.Expect(env.Get(ctx, cmKey, cm)).To(Succeed())
+
+		cm.Labels = map[string]string{"foo": "bar"}
+
+		// The CRS controller writes a lastAppliedTime field, which is of type metav1.Time. The precision at most a
+		// second. Therefore, if the controller re-applies the resource twice within one second, the lastAppliedTime
+		// value is unlikely to change. Our test below compares the lastAppliedTime values of two reconciles, so we wait
+		// to prevent the reconciles from running within the same second. Related issue: https://issues.k8s.io/15262
+		t.Log("Letting some time pass before updating the resource, so that lastAppliedTime will be different.")
+		time.Sleep(10 * time.Second)
+
+		// update the configmap data
+		t.Log("Updating the configmap resource")
+		g.Expect(env.Update(ctx, cm)).To(Succeed())
+
+		t.Log("Verifying that resource is not re-applied over a period of time.")
+		g.Consistently(func() bool {
+			binding := &addonsv1.ClusterResourceSetBinding{}
+			err := env.Get(ctx, clusterResourceSetBindingKey, binding)
+			if err != nil {
+				return false
+			}
+
+			bindings := binding.Spec.Bindings
+			// only one resource is applied
+			resource := bindings[0].Resources[0]
+			return oldHash == resource.Hash && oldLastAppliedTime.Equal(resource.LastAppliedTime)
+		}, timeout).Should(BeTrue())
+	})
+
+	t.Run("Should create ClusterResourceSet with strategy 'AlwaysApply' and reconcile secrets only once if data has not changed", func(t *testing.T) {
+		g := NewWithT(t)
+		ns := setup(t, g)
+		defer teardown(t, g, ns)
+
+		t.Log("Updating the cluster with labels")
+		testCluster.SetLabels(labels)
+		g.Expect(env.Update(ctx, testCluster)).To(Succeed())
+
+		clusterResourceSetInstance := &addonsv1.ClusterResourceSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      clusterResourceSetName,
+				Namespace: ns.Name,
+			},
+			Spec: addonsv1.ClusterResourceSetSpec{
+				ClusterSelector: metav1.LabelSelector{
+					MatchLabels: labels,
+				},
+				Strategy:  "ApplyAlways",
+				Resources: []addonsv1.ResourceRef{{Name: secretName, Kind: "Secret"}},
+			},
+		}
+		// Create the ClusterResourceSet.
+		g.Expect(env.Create(ctx, clusterResourceSetInstance)).To(Succeed())
+
+		// Wait until ClusterResourceSetBinding is created for the Cluster
+		clusterResourceSetBindingKey := client.ObjectKey{
+			Namespace: testCluster.Namespace,
+			Name:      testCluster.Name,
+		}
+
+		t.Log("Waiting for the ClusterResourceSetBinding to be created")
+		oldHash := ""
+		var oldLastAppliedTime *metav1.Time
+		g.Eventually(func() bool {
+			binding := &addonsv1.ClusterResourceSetBinding{}
+			err := env.Get(ctx, clusterResourceSetBindingKey, binding)
+			if err != nil {
+				return false
+			}
+
+			bindings := binding.Spec.Bindings
+			// should only have one binding
+			if len(bindings) != 1 {
+				return false
+			}
+
+			// only one resource is applied
+			resource := bindings[0].Resources[0]
+			oldHash = resource.Hash
+			oldLastAppliedTime = resource.LastAppliedTime
+			return resource.Applied
+		}, timeout).Should(BeTrue())
+
+		secretKey := client.ObjectKey{
+			Namespace: ns.Name,
+			Name:      secretName,
+		}
+		secret := &corev1.Secret{}
+		g.Expect(env.Get(ctx, secretKey, secret)).To(Succeed())
+
+		// Overwrite the Secret labels to cause the ClusterResourceSet controller to reconcile any CRS that references
+		// the Secret.
+		secret.Labels = map[string]string{"foo": "bar"}
+
+		// The CRS controller writes a lastAppliedTime field, which is of type metav1.Time. The precision at most a
+		// second. Therefore, if the controller re-applies the resource twice within one second, the lastAppliedTime
+		// value is unlikely to change. Our test below compares the lastAppliedTime values of two reconciles, so we wait
+		// to prevent the reconciles from running within the same second. Related issue: https://issues.k8s.io/15262
+		t.Log("Letting some time pass before updating the resource, so that lastAppliedTime will be different.")
+		time.Sleep(10 * time.Second)
+
+		// update the secrete, but not its data
+		t.Log("Updating the secret resource")
+		g.Expect(env.Update(ctx, secret)).To(Succeed())
+
+		t.Log("Verifying that resource is not re-applied over a period of time.")
+		g.Consistently(func() bool {
+			binding := &addonsv1.ClusterResourceSetBinding{}
+			err := env.Get(ctx, clusterResourceSetBindingKey, binding)
+			if err != nil {
+				return false
+			}
+
+			bindings := binding.Spec.Bindings
+			// only one resource is applied
+			resource := bindings[0].Resources[0]
+			return oldHash == resource.Hash && oldLastAppliedTime.Equal(resource.LastAppliedTime)
 		}, timeout).Should(BeTrue())
 	})
 }

--- a/exp/addons/internal/controllers/clusterresourceset_controller_test.go
+++ b/exp/addons/internal/controllers/clusterresourceset_controller_test.go
@@ -34,7 +34,8 @@ import (
 )
 
 const (
-	timeout = time.Second * 15
+	timeout          = time.Second * 15
+	reconcileTimeout = time.Second * 15
 )
 
 func TestClusterResourceSetReconciler(t *testing.T) {
@@ -70,11 +71,11 @@ func TestClusterResourceSetReconciler(t *testing.T) {
 				Namespace: ns.Name,
 			},
 			Data: map[string]string{
-				"cm": `metadata:
- name: resource-configmap
- namespace: default
-kind: ConfigMap
-apiVersion: v1`,
+				"cm": `kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: resource-configmap
+  namespace: default`,
 			},
 		}
 		testSecret := &corev1.Secret{
@@ -84,12 +85,11 @@ apiVersion: v1`,
 			},
 			Type: "addons.cluster.x-k8s.io/resource-set",
 			StringData: map[string]string{
-				"cm": `metadata:
-kind: ConfigMap
+				"cm": `kind: ConfigMap
 apiVersion: v1
 metadata:
- name: resource-configmap
- namespace: default`,
+  name: resource-configmap
+  namespace: default`,
 			},
 		}
 		t.Log("Creating a Secret and a ConfigMap with ConfigMap in their data field")
@@ -587,5 +587,219 @@ metadata:
 			}
 			return false
 		}, timeout).Should(BeTrue())
+	})
+
+	t.Run("Should create ClusterResourceSet with strategy 'AlwaysApply' and reconcile when configmap changes data", func(t *testing.T) {
+		g := NewWithT(t)
+		ns := setup(t, g)
+		defer teardown(t, g, ns)
+
+		t.Log("Updating the cluster with labels")
+		testCluster.SetLabels(labels)
+		g.Expect(env.Update(ctx, testCluster)).To(Succeed())
+
+		clusterResourceSetInstance := &addonsv1.ClusterResourceSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      clusterResourceSetName,
+				Namespace: ns.Name,
+			},
+			Spec: addonsv1.ClusterResourceSetSpec{
+				ClusterSelector: metav1.LabelSelector{
+					MatchLabels: labels,
+				},
+				Strategy:  "ApplyAlways",
+				Resources: []addonsv1.ResourceRef{{Name: configmapName, Kind: "ConfigMap"}},
+			},
+		}
+		// Create the ClusterResourceSet.
+		g.Expect(env.Create(ctx, clusterResourceSetInstance)).To(Succeed())
+
+		// Wait until ClusterResourceSetBinding is created for the Cluster
+		clusterResourceSetBindingKey := client.ObjectKey{
+			Namespace: testCluster.Namespace,
+			Name:      testCluster.Name,
+		}
+
+		t.Log("Getting ClusterResourceSetBinding")
+		oldHash := ""
+		var lastApplied *metav1.Time
+		g.Eventually(func() bool {
+			binding := &addonsv1.ClusterResourceSetBinding{}
+			err := env.Get(ctx, clusterResourceSetBindingKey, binding)
+			if err != nil {
+				return false
+			}
+
+			bindings := binding.Spec.Bindings
+			// should only have one binding
+			if len(bindings) != 1 {
+				return false
+			}
+
+			// only one resource is applied
+			resource := bindings[0].Resources[0]
+			oldHash = resource.Hash
+			lastApplied = resource.LastAppliedTime
+
+			return resource.Applied
+
+		}, timeout).Should(BeTrue())
+
+		// Get configmap obj, update the configmap
+		cmKey := client.ObjectKey{
+			Namespace: ns.Name,
+			Name:      configmapName,
+		}
+		cm := &corev1.ConfigMap{}
+		g.Expect(env.Get(ctx, cmKey, cm)).To(Succeed())
+
+		cmUpdate := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            cm.GetName(),
+				Namespace:       cm.GetNamespace(),
+				ResourceVersion: cm.ResourceVersion,
+				UID:             cm.GetUID(),
+			},
+			Data: map[string]string{
+				"cm": `kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: resource-configmap
+  namespace: default
+data: 
+  hello: "world!"`,
+			},
+		}
+
+		// update the configmap data
+		t.Log("Updating the configmap resource")
+		g.Expect(env.Update(ctx, cmUpdate)).To(Succeed())
+
+		t.Log("Check if reconciled hash has updated for the changed configmap resource")
+		g.Eventually(func() bool {
+			binding := &addonsv1.ClusterResourceSetBinding{}
+			err := env.Get(ctx, clusterResourceSetBindingKey, binding)
+			if err != nil {
+				return false
+			}
+
+			bindings := binding.Spec.Bindings
+			// should only have one binding
+			if len(bindings) != 1 {
+				return false
+			}
+
+			// only one resource is applied
+			resource := bindings[0].Resources[0]
+			return resource.Hash != oldHash && resource.Applied && !lastApplied.Equal(resource.LastAppliedTime)
+
+		}, reconcileTimeout).Should(BeTrue())
+	})
+
+	t.Run("Should create ClusterResourceSet with strategy 'AlwaysApply' and reconcile when secret changes data", func(t *testing.T) {
+		g := NewWithT(t)
+		ns := setup(t, g)
+		defer teardown(t, g, ns)
+
+		t.Log("Updating the cluster with labels")
+		testCluster.SetLabels(labels)
+		g.Expect(env.Update(ctx, testCluster)).To(Succeed())
+
+		clusterResourceSetInstance := &addonsv1.ClusterResourceSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      clusterResourceSetName,
+				Namespace: ns.Name,
+			},
+			Spec: addonsv1.ClusterResourceSetSpec{
+				ClusterSelector: metav1.LabelSelector{
+					MatchLabels: labels,
+				},
+				Strategy:  "ApplyAlways",
+				Resources: []addonsv1.ResourceRef{{Name: secretName, Kind: "Secret"}},
+			},
+		}
+		// Create the ClusterResourceSet.
+		g.Expect(env.Create(ctx, clusterResourceSetInstance)).To(Succeed())
+
+		// Wait until ClusterResourceSetBinding is created for the Cluster
+		clusterResourceSetBindingKey := client.ObjectKey{
+			Namespace: testCluster.Namespace,
+			Name:      testCluster.Name,
+		}
+
+		t.Log("Getting ClusterResourceSetBinding")
+		oldHash := ""
+		var lastApplied *metav1.Time
+		g.Eventually(func() bool {
+			binding := &addonsv1.ClusterResourceSetBinding{}
+			err := env.Get(ctx, clusterResourceSetBindingKey, binding)
+			if err != nil {
+				return false
+			}
+
+			bindings := binding.Spec.Bindings
+			// should only have one binding
+			if len(bindings) != 1 {
+				return false
+			}
+
+			// only one resource is applied
+			resource := bindings[0].Resources[0]
+			oldHash = resource.Hash
+			lastApplied = resource.LastAppliedTime
+
+			return resource.Applied
+
+		}, timeout).Should(BeTrue())
+
+		secretKey := client.ObjectKey{
+			Namespace: ns.Name,
+			Name:      secretName,
+		}
+		secret := &corev1.Secret{}
+		g.Expect(env.Get(ctx, secretKey, secret)).To(Succeed())
+
+		secretUpdate := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            secret.GetName(),
+				Namespace:       secret.GetNamespace(),
+				ResourceVersion: secret.ResourceVersion,
+				UID:             secret.GetUID(),
+			},
+			Type: "addons.cluster.x-k8s.io/resource-set",
+			StringData: map[string]string{
+				"cm": `kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: resource-configmap
+  namespace: default
+data: 
+  hello: "world!"`,
+			},
+		}
+
+		// update the configmap data
+		t.Log("Updating the secret resource")
+		g.Expect(env.Update(ctx, secretUpdate)).To(Succeed())
+
+		t.Log("Check if reconciled hash has updated for the changed secret resource")
+		g.Eventually(func() bool {
+			binding := &addonsv1.ClusterResourceSetBinding{}
+			err := env.Get(ctx, clusterResourceSetBindingKey, binding)
+			if err != nil {
+				return false
+			}
+
+			bindings := binding.Spec.Bindings
+			// should only have one binding
+			if len(bindings) != 1 {
+				return false
+			}
+
+			// only one resource is applied
+			resource := bindings[0].Resources[0]
+			return resource.Hash != oldHash && resource.Applied && !lastApplied.Equal(resource.LastAppliedTime)
+
+		}, reconcileTimeout).Should(BeTrue())
 	})
 }

--- a/exp/addons/internal/controllers/clusterresourceset_controller_test.go
+++ b/exp/addons/internal/controllers/clusterresourceset_controller_test.go
@@ -622,7 +622,6 @@ metadata:
 
 		t.Log("Getting ClusterResourceSetBinding")
 		oldHash := ""
-		var lastApplied *metav1.Time
 		g.Eventually(func() bool {
 			binding := &addonsv1.ClusterResourceSetBinding{}
 			err := env.Get(ctx, clusterResourceSetBindingKey, binding)
@@ -639,8 +638,6 @@ metadata:
 			// only one resource is applied
 			resource := bindings[0].Resources[0]
 			oldHash = resource.Hash
-			lastApplied = resource.LastAppliedTime
-
 			return resource.Applied
 
 		}, timeout).Should(BeTrue())
@@ -691,7 +688,8 @@ data:
 
 			// only one resource is applied
 			resource := bindings[0].Resources[0]
-			return resource.Hash != oldHash && resource.Applied && !lastApplied.Equal(resource.LastAppliedTime)
+			t.Logf("old hash and new binding: %s, %v", oldHash, resource)
+			return resource.Hash != oldHash
 
 		}, reconcileTimeout).Should(BeTrue())
 	})
@@ -729,7 +727,6 @@ data:
 
 		t.Log("Getting ClusterResourceSetBinding")
 		oldHash := ""
-		var lastApplied *metav1.Time
 		g.Eventually(func() bool {
 			binding := &addonsv1.ClusterResourceSetBinding{}
 			err := env.Get(ctx, clusterResourceSetBindingKey, binding)
@@ -746,8 +743,6 @@ data:
 			// only one resource is applied
 			resource := bindings[0].Resources[0]
 			oldHash = resource.Hash
-			lastApplied = resource.LastAppliedTime
-
 			return resource.Applied
 
 		}, timeout).Should(BeTrue())
@@ -783,6 +778,7 @@ data:
 		g.Expect(env.Update(ctx, secretUpdate)).To(Succeed())
 
 		t.Log("Check if reconciled hash has updated for the changed secret resource")
+
 		g.Eventually(func() bool {
 			binding := &addonsv1.ClusterResourceSetBinding{}
 			err := env.Get(ctx, clusterResourceSetBindingKey, binding)
@@ -798,7 +794,8 @@ data:
 
 			// only one resource is applied
 			resource := bindings[0].Resources[0]
-			return resource.Hash != oldHash && resource.Applied && !lastApplied.Equal(resource.LastAppliedTime)
+			t.Logf("old hash and new binding: %s, %v", oldHash, resource)
+			return resource.Hash != oldHash
 
 		}, reconcileTimeout).Should(BeTrue())
 	})

--- a/exp/addons/internal/controllers/clusterresourceset_controller_test.go
+++ b/exp/addons/internal/controllers/clusterresourceset_controller_test.go
@@ -34,8 +34,7 @@ import (
 )
 
 const (
-	timeout          = time.Second * 15
-	reconcileTimeout = time.Second * 15
+	timeout = time.Second * 15
 )
 
 func TestClusterResourceSetReconciler(t *testing.T) {
@@ -639,7 +638,6 @@ metadata:
 			resource := bindings[0].Resources[0]
 			oldHash = resource.Hash
 			return resource.Applied
-
 		}, timeout).Should(BeTrue())
 
 		// Get configmap obj, update the configmap
@@ -688,10 +686,8 @@ data:
 
 			// only one resource is applied
 			resource := bindings[0].Resources[0]
-			t.Logf("old hash and new binding: %s, %v", oldHash, resource)
 			return resource.Hash != oldHash
-
-		}, reconcileTimeout).Should(BeTrue())
+		}, timeout).Should(BeTrue())
 	})
 
 	t.Run("Should create ClusterResourceSet with strategy 'AlwaysApply' and reconcile when secret changes data", func(t *testing.T) {
@@ -744,7 +740,6 @@ data:
 			resource := bindings[0].Resources[0]
 			oldHash = resource.Hash
 			return resource.Applied
-
 		}, timeout).Should(BeTrue())
 
 		secretKey := client.ObjectKey{
@@ -778,7 +773,6 @@ data:
 		g.Expect(env.Update(ctx, secretUpdate)).To(Succeed())
 
 		t.Log("Check if reconciled hash has updated for the changed secret resource")
-
 		g.Eventually(func() bool {
 			binding := &addonsv1.ClusterResourceSetBinding{}
 			err := env.Get(ctx, clusterResourceSetBindingKey, binding)
@@ -794,9 +788,7 @@ data:
 
 			// only one resource is applied
 			resource := bindings[0].Resources[0]
-			t.Logf("old hash and new binding: %s, %v", oldHash, resource)
 			return resource.Hash != oldHash
-
-		}, reconcileTimeout).Should(BeTrue())
+		}, timeout).Should(BeTrue())
 	})
 }

--- a/exp/addons/internal/controllers/clusterresourceset_helpers.go
+++ b/exp/addons/internal/controllers/clusterresourceset_helpers.go
@@ -55,7 +55,7 @@ func isJSONList(data []byte) (bool, error) {
 	return bytes.HasPrefix(trim, jsonListPrefix), nil
 }
 
-func apply(ctx context.Context, c client.Client, data []byte) error {
+func apply(ctx context.Context, c client.Client, strategy addonsv1.ClusterResourceSetStrategy, data []byte) error {
 	isJSONList, err := isJSONList(data)
 	if err != nil {
 		return err
@@ -83,29 +83,61 @@ func apply(ctx context.Context, c client.Client, data []byte) error {
 	errList := []error{}
 	sortedObjs := utilresource.SortForCreate(objs)
 	for i := range sortedObjs {
-		if err := applyUnstructured(ctx, c, &sortedObjs[i]); err != nil {
+		if err := applyUnstructured(ctx, c, strategy, &sortedObjs[i]); err != nil {
 			errList = append(errList, err)
 		}
 	}
 	return kerrors.NewAggregate(errList)
 }
 
-func applyUnstructured(ctx context.Context, c client.Client, obj *unstructured.Unstructured) error {
+func applyUnstructured(ctx context.Context, c client.Client, strategy addonsv1.ClusterResourceSetStrategy, obj *unstructured.Unstructured) error {
 	// Create the object on the API server.
 	// TODO: Errors are only logged. If needed, exponential backoff or requeuing could be used here for remedying connection glitches etc.
 	if err := c.Create(ctx, obj); err != nil {
 		// The create call is idempotent, so if the object already exists
 		// then do not consider it to be an error.
-		if !apierrors.IsAlreadyExists(err) {
-			return errors.Wrapf(
-				err,
-				"failed to create object %s %s/%s",
-				obj.GroupVersionKind(),
-				obj.GetNamespace(),
-				obj.GetName())
+		if apierrors.IsAlreadyExists(err) {
+			if strategy == addonsv1.ClusterResourceSetStrategyApplyAlways {
+				// The object here has already been created, so attempt to
+				// update the object here. first we must get the obj we are trying to update and get the ResourceVersion
+
+				objKey := client.ObjectKey{
+					Namespace: obj.GetNamespace(),
+					Name:      obj.GetName(),
+				}
+
+				// this will be the object that currently exists in the api
+				existingObj := &unstructured.Unstructured{}
+				existingObj.SetAPIVersion(obj.GetAPIVersion())
+				existingObj.SetKind(obj.GetKind())
+
+				errGet := c.Get(ctx, objKey, existingObj)
+				if errGet != nil {
+					return wrapClientError(obj, "get", errGet)
+				}
+				obj.SetUID(existingObj.GetUID())
+				obj.SetResourceVersion(existingObj.GetResourceVersion())
+
+				errUpdating := c.Update(ctx, obj)
+				if errUpdating != nil {
+					return wrapClientError(obj, "update", errUpdating)
+				}
+			}
+		} else {
+			return wrapClientError(obj, "create", err)
 		}
 	}
 	return nil
+}
+
+func wrapClientError(obj *unstructured.Unstructured, clientOperation string, err error) error {
+	return errors.Wrapf(
+		err,
+		"failed to %s object %s %s/%s",
+		clientOperation,
+		obj.GroupVersionKind(),
+		obj.GetNamespace(),
+		obj.GetName())
 }
 
 // getOrCreateClusterResourceSetBinding retrieves ClusterResourceSetBinding resource owned by the cluster or create a new one if not found.

--- a/exp/addons/internal/controllers/clusterresourcesetbinding_controller.go
+++ b/exp/addons/internal/controllers/clusterresourcesetbinding_controller.go
@@ -18,7 +18,6 @@ package controllers
 
 import (
 	"context"
-
 	"github.com/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"

--- a/exp/addons/internal/controllers/clusterresourcesetbinding_controller.go
+++ b/exp/addons/internal/controllers/clusterresourcesetbinding_controller.go
@@ -18,6 +18,7 @@ package controllers
 
 import (
 	"context"
+
 	"github.com/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"

--- a/exp/addons/internal/controllers/predicates/resource_predicates.go
+++ b/exp/addons/internal/controllers/predicates/resource_predicates.go
@@ -32,3 +32,13 @@ func ResourceCreate(logger logr.Logger) predicate.Funcs {
 		GenericFunc: func(e event.GenericEvent) bool { return false },
 	}
 }
+
+// ResourceCreateUpdate returns a predicate that returns true for a create or update event.
+func ResourceCreateUpdate(logger logr.Logger) predicate.Funcs {
+	return predicate.Funcs{
+		CreateFunc:  func(e event.CreateEvent) bool { return true },
+		UpdateFunc:  func(e event.UpdateEvent) bool { return true },
+		DeleteFunc:  func(e event.DeleteEvent) bool { return false },
+		GenericFunc: func(e event.GenericEvent) bool { return false },
+	}
+}


### PR DESCRIPTION
This PR includes all downstream commits cherry-picked from the v1.1.3-d2iq.5 release, with conflicts resolved.

1. I created the `d2iq/release-1.2.2` and `dlipovetsky/release-1.2.2-patches` branches, both pointed at the `v1.2.2` tag.

2. I generated the range of commits:

```shell
DOWNSTREAM=v1.1.3-d2iq.5
UPSTREAM=v1.1.3
RANGE="$(git log "$UPSTREAM".."$DOWNSTREAM" --pretty=format:"%h" | tail -1)^..$(git log "$DOWNSTREAM" -n 1 --pretty=format:"%h")"
```

3. I cherry-picked the commits onto the `dlipovetsky/release-1.2.2-patches` branch:

```shell
git checkout dlipovetsky/release-1.2.2-patches
git cherry-pick "$RANGE"
```

4.  I resolved the conflicts, and committed the changes.

5. I pushed the `dlipovetsky/release-1.2.2-patches` branch, and opened this PR.