### PR TITLE
:bug: fix: do not use mutators for `from` cluster

### DIFF
--- a/cmd/clusterctl/client/cluster/mover.go
+++ b/cmd/clusterctl/client/cluster/mover.go
@@ -345,12 +345,12 @@ func (o *objectMover) move(graph *objectGraph, toProxy Proxy, mutators ...Resour
 
 	// Sets the pause field on the Cluster object in the source management cluster, so the controllers stop reconciling it.
 	log.V(1).Info("Pausing the source cluster")
-	if err := setClusterPause(o.fromProxy, clusters, true, o.dryRun, mutators...); err != nil {
+	if err := setClusterPause(o.fromProxy, clusters, true, o.dryRun); err != nil {
 		return err
 	}
 
 	log.V(1).Info("Pausing the source ClusterClasses")
-	if err := setClusterClassPause(o.fromProxy, clusterClasses, true, o.dryRun, mutators...); err != nil {
+	if err := setClusterClassPause(o.fromProxy, clusterClasses, true, o.dryRun); err != nil {
 		return errors.Wrap(err, "error pausing ClusterClasses")
 	}
 


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Follow up of #14 where when addressing some review comments, I mistakenly added resource mutators in functions that are meant for `from` cluster. Mutators are meant only for `to` cluster and I overlooked this during one of the refactors done while addressing review comments.

https://github.com/kubernetes-sigs/cluster-api/pull/7966 already has this change https://github.com/kubernetes-sigs/cluster-api/pull/7966/files#diff-3458bf9e9c245fe801573500c33de535f05d3a5887f080a405b819e3c0fed415R326-R331. I just messed up when refactoring on our fork. That being said, We now have an e2e test that asserts for this so the move should be functioning correctly. Previously i relied on manual testing - which passed in the initial state of #14 but that PR digressed after my manual test. [This run of TC build](https://teamcity.mesosphere.io/buildConfiguration/MesosphereOnly_ClosedSource_E2E_Kommander_E2eEssentialToEnterpriseKonvoyAWS/3849397?buildTab=artifacts#%2Ffeature%2Fessential_to_enterprise%2Fsuites%2Faws%2Fmgmt-repo;%2Ffeature%2Fessential_to_enterprise%2Fsuites%2Faws%2Fsupport-bundle-2023-02-18T04_02_10.tar.gz;%2Ffeature%2Fessential_to_enterprise%2Fsuites%2Faws%2Fsupport-bundle-2023-02-18T03_56_51.tar.gz!%2Fsupport-bundle-2023-02-18T03_56_51%2Fpod-logs%2Fkommander) has  [logs showing the move](https://teamcity.mesosphere.io/repository/download/MesosphereOnly_ClosedSource_E2E_Kommander_E2eEssentialToEnterpriseKonvoyAWS/3849397:id/feature/essential_to_enterprise/suites/aws/support-bundle-2023-02-18T03_56_51.tar.gz!/support-bundle-2023-02-18T03_56_51/pod-logs/kommander/kommander-cm-c88f9fc65-khhqr-controller-manager.log):
```
cat kommander-cm-c88f9fc65-khhqr-controller-manager.log| grep cluster-api
2023-02-18T03:47:29.855Z	INFO	cluster-api.CAPIResource	Performing move...
2023-02-18T03:47:30.362Z	INFO	cluster-api.CAPIResource	Discovering Cluster API objects
2023-02-18T03:47:35.346Z	DEBUG	cluster-api.CAPIResource	Total objects	{"Count": 36}
2023-02-18T03:47:35.467Z	INFO	cluster-api.CAPIResource	Moving Cluster API objects	{"Clusters": 1}
2023-02-18T03:47:35.467Z	INFO	cluster-api.CAPIResource	Moving Cluster API objects	{"ClusterClasses": 0}
2023-02-18T03:47:35.467Z	DEBUG	cluster-api.CAPIResource	Pausing the source cluster
2023-02-18T03:47:35.642Z	DEBUG	cluster-api.CAPIResource	Pausing the source ClusterClasses
2023-02-18T03:47:35.642Z	DEBUG	cluster-api.CAPIResource	Creating target namespaces, if missing
2023-02-18T03:47:35.743Z	INFO	cluster-api.CAPIResource	Creating objects in the target cluster
2023-02-18T03:47:35.744Z	DEBUG	cluster-api.CAPIResource	Creating	{"ClusterResourceSet": "aws-ebs-csi-kind-kare", "Namespace": "default"}
2023-02-18T03:47:36.068Z	DEBUG	cluster-api.CAPIResource	Creating	{"ClusterResourceSet": "cluster-autoscaler-kind-kare", "Namespace": "default"}
2023-02-18T03:47:36.171Z	DEBUG	cluster-api.CAPIResource	Creating	{"ClusterResourceSet": "node-feature-discovery-kind-kare", "Namespace": "default"}
2023-02-18T03:47:36.380Z	DEBUG	cluster-api.CAPIResource	Creating	{"AWSClusterControllerIdentity": "default", "Namespace": ""}
2023-02-18T03:47:36.486Z	DEBUG	cluster-api.CAPIResource	Creating	{"Secret": "kind-kare-etcd-encryption-config", "Namespace": "default"}
2023-02-18T03:47:36.669Z	DEBUG	cluster-api.CAPIResource	Creating	{"ClusterResourceSet": "calico-cni-installation-kind-kare", "Namespace": "default"}
2023-02-18T03:47:37.055Z	DEBUG	cluster-api.CAPIResource	Creating	{"Cluster": "kind-kare", "Namespace": "default"}
2023-02-18T03:47:37.375Z	DEBUG	cluster-api.CAPIResource	Creating	{"ClusterResourceSetBinding": "kind-kare", "Namespace": "default"}
2023-02-18T03:47:37.488Z	DEBUG	cluster-api.CAPIResource	Creating	{"KubeadmControlPlane": "kind-kare-control-plane", "Namespace": "default"}
2023-02-18T03:47:37.757Z	DEBUG	cluster-api.CAPIResource	Creating	{"AWSCluster": "kind-kare", "Namespace": "default"}
2023-02-18T03:47:38.072Z	DEBUG	cluster-api.CAPIResource	Creating	{"ConfigMap": "calico-cni-installation-kind-kare", "Namespace": "default"}
2023-02-18T03:47:38.355Z	DEBUG	cluster-api.CAPIResource	Creating	{"ConfigMap": "cluster-autoscaler-kind-kare", "Namespace": "default"}
2023-02-18T03:47:38.550Z	DEBUG	cluster-api.CAPIResource	Creating	{"AWSMachineTemplate": "kind-kare-md-0", "Namespace": "default"}
2023-02-18T03:47:38.763Z	DEBUG	cluster-api.CAPIResource	Creating	{"ConfigMap": "aws-ebs-csi-kind-kare", "Namespace": "default"}
2023-02-18T03:47:39.070Z	DEBUG	cluster-api.CAPIResource	Creating	{"ConfigMap": "node-feature-discovery-kind-kare", "Namespace": "default"}
2023-02-18T03:47:39.342Z	DEBUG	cluster-api.CAPIResource	Creating	{"MachineDeployment": "kind-kare-md-0", "Namespace": "default"}
2023-02-18T03:47:39.698Z	DEBUG	cluster-api.CAPIResource	Creating	{"AWSMachineTemplate": "kind-kare-control-plane", "Namespace": "default"}
2023-02-18T03:47:40.256Z	DEBUG	cluster-api.CAPIResource	Creating	{"KubeadmConfigTemplate": "kind-kare-md-0", "Namespace": "default"}
2023-02-18T03:47:40.577Z	DEBUG	cluster-api.CAPIResource	Creating	{"ConfigMap": "tigera-operator-kind-kare", "Namespace": "default"}
2023-02-18T03:47:41.372Z	DEBUG	cluster-api.CAPIResource	Creating	{"Secret": "kind-kare-ca", "Namespace": "default"}
2023-02-18T03:47:41.571Z	DEBUG	cluster-api.CAPIResource	Creating	{"Secret": "kind-kare-sa", "Namespace": "default"}
2023-02-18T03:47:41.755Z	DEBUG	cluster-api.CAPIResource	Creating	{"Secret": "kind-kare-kubeconfig", "Namespace": "default"}
2023-02-18T03:47:41.959Z	DEBUG	cluster-api.CAPIResource	Creating	{"Secret": "kind-kare-proxy", "Namespace": "default"}
2023-02-18T03:47:42.149Z	DEBUG	cluster-api.CAPIResource	Creating	{"Secret": "kind-kare-etcd", "Namespace": "default"}
2023-02-18T03:47:42.278Z	DEBUG	cluster-api.CAPIResource	Creating	{"Machine": "kind-kare-control-plane-g8mqb", "Namespace": "default"}
2023-02-18T03:47:42.489Z	DEBUG	cluster-api.CAPIResource	Creating	{"MachineSet": "kind-kare-md-0-5d6dfdccc4", "Namespace": "default"}
2023-02-18T03:47:42.676Z	DEBUG	cluster-api.CAPIResource	Creating	{"AWSMachine": "kind-kare-control-plane-qhfb2", "Namespace": "default"}
2023-02-18T03:47:42.872Z	DEBUG	cluster-api.CAPIResource	Creating	{"KubeadmConfig": "kind-kare-control-plane-szbbr", "Namespace": "default"}
2023-02-18T03:47:43.012Z	DEBUG	cluster-api.CAPIResource	Creating	{"Machine": "kind-kare-md-0-5d6dfdccc4-2zcmq", "Namespace": "default"}
2023-02-18T03:47:43.180Z	DEBUG	cluster-api.CAPIResource	Creating	{"Secret": "kind-kare-control-plane-szbbr", "Namespace": "default"}
2023-02-18T03:47:43.365Z	DEBUG	cluster-api.CAPIResource	Creating	{"KubeadmConfig": "kind-kare-md-0-6vbtd", "Namespace": "default"}
2023-02-18T03:47:43.571Z	DEBUG	cluster-api.CAPIResource	Creating	{"AWSMachine": "kind-kare-md-0-bm78j", "Namespace": "default"}
2023-02-18T03:47:43.684Z	DEBUG	cluster-api.CAPIResource	Creating	{"Secret": "kind-kare-md-0-6vbtd", "Namespace": "default"}
2023-02-18T03:47:43.875Z	INFO	cluster-api.CAPIResource	Deleting objects from the source cluster
2023-02-18T03:47:43.875Z	DEBUG	cluster-api.CAPIResource	Deleting	{"Secret": "kind-kare-md-0-6vbtd", "Namespace": "default"}
2023-02-18T03:47:43.960Z	DEBUG	cluster-api.CAPIResource	Deleting	{"Secret": "kind-kare-control-plane-szbbr", "Namespace": "default"}
2023-02-18T03:47:43.982Z	DEBUG	cluster-api.CAPIResource	Deleting	{"KubeadmConfig": "kind-kare-md-0-6vbtd", "Namespace": "default"}
2023-02-18T03:47:44.056Z	DEBUG	cluster-api.CAPIResource	Deleting	{"AWSMachine": "kind-kare-md-0-bm78j", "Namespace": "default"}
2023-02-18T03:47:44.171Z	DEBUG	cluster-api.CAPIResource	Deleting	{"AWSMachine": "kind-kare-control-plane-qhfb2", "Namespace": "default"}
2023-02-18T03:47:44.209Z	DEBUG	cluster-api.CAPIResource	Deleting	{"KubeadmConfig": "kind-kare-control-plane-szbbr", "Namespace": "default"}
2023-02-18T03:47:44.265Z	DEBUG	cluster-api.CAPIResource	Deleting	{"Machine": "kind-kare-md-0-5d6dfdccc4-2zcmq", "Namespace": "default"}
2023-02-18T03:47:44.323Z	DEBUG	cluster-api.CAPIResource	Deleting	{"Secret": "kind-kare-ca", "Namespace": "default"}
2023-02-18T03:47:44.349Z	DEBUG	cluster-api.CAPIResource	Deleting	{"Secret": "kind-kare-sa", "Namespace": "default"}
2023-02-18T03:47:44.374Z	DEBUG	cluster-api.CAPIResource	Deleting	{"Secret": "kind-kare-kubeconfig", "Namespace": "default"}
2023-02-18T03:47:44.461Z	DEBUG	cluster-api.CAPIResource	Deleting	{"Secret": "kind-kare-proxy", "Namespace": "default"}
2023-02-18T03:47:44.552Z	DEBUG	cluster-api.CAPIResource	Deleting	{"Secret": "kind-kare-etcd", "Namespace": "default"}
2023-02-18T03:47:44.574Z	DEBUG	cluster-api.CAPIResource	Deleting	{"Machine": "kind-kare-control-plane-g8mqb", "Namespace": "default"}
2023-02-18T03:47:44.666Z	DEBUG	cluster-api.CAPIResource	Deleting	{"MachineSet": "kind-kare-md-0-5d6dfdccc4", "Namespace": "default"}
2023-02-18T03:47:44.694Z	DEBUG	cluster-api.CAPIResource	Deleting	{"ClusterResourceSetBinding": "kind-kare", "Namespace": "default"}
2023-02-18T03:47:44.755Z	DEBUG	cluster-api.CAPIResource	Deleting	{"KubeadmControlPlane": "kind-kare-control-plane", "Namespace": "default"}
2023-02-18T03:47:44.886Z	DEBUG	cluster-api.CAPIResource	Deleting	{"AWSCluster": "kind-kare", "Namespace": "default"}
2023-02-18T03:47:44.951Z	DEBUG	cluster-api.CAPIResource	Deleting	{"ConfigMap": "calico-cni-installation-kind-kare", "Namespace": "default"}
2023-02-18T03:47:44.983Z	DEBUG	cluster-api.CAPIResource	Deleting	{"ConfigMap": "cluster-autoscaler-kind-kare", "Namespace": "default"}
2023-02-18T03:47:45.006Z	DEBUG	cluster-api.CAPIResource	Deleting	{"AWSMachineTemplate": "kind-kare-md-0", "Namespace": "default"}
2023-02-18T03:47:45.057Z	DEBUG	cluster-api.CAPIResource	Deleting	{"ConfigMap": "aws-ebs-csi-kind-kare", "Namespace": "default"}
2023-02-18T03:47:45.157Z	DEBUG	cluster-api.CAPIResource	Deleting	{"ConfigMap": "node-feature-discovery-kind-kare", "Namespace": "default"}
2023-02-18T03:47:45.181Z	DEBUG	cluster-api.CAPIResource	Deleting	{"MachineDeployment": "kind-kare-md-0", "Namespace": "default"}
2023-02-18T03:47:45.253Z	DEBUG	cluster-api.CAPIResource	Deleting	{"AWSMachineTemplate": "kind-kare-control-plane", "Namespace": "default"}
2023-02-18T03:47:45.277Z	DEBUG	cluster-api.CAPIResource	Deleting	{"KubeadmConfigTemplate": "kind-kare-md-0", "Namespace": "default"}
2023-02-18T03:47:45.352Z	DEBUG	cluster-api.CAPIResource	Deleting	{"ConfigMap": "tigera-operator-kind-kare", "Namespace": "default"}
2023-02-18T03:47:45.712Z	DEBUG	cluster-api.CAPIResource	Deleting	{"ClusterResourceSet": "aws-ebs-csi-kind-kare", "Namespace": "default"}
2023-02-18T03:47:45.758Z	DEBUG	cluster-api.CAPIResource	Deleting	{"ClusterResourceSet": "cluster-autoscaler-kind-kare", "Namespace": "default"}
2023-02-18T03:47:45.790Z	DEBUG	cluster-api.CAPIResource	Deleting	{"ClusterResourceSet": "node-feature-discovery-kind-kare", "Namespace": "default"}
2023-02-18T03:47:45.833Z	DEBUG	cluster-api.CAPIResource	Deleting	{"Secret": "kind-kare-etcd-encryption-config", "Namespace": "default"}
2023-02-18T03:47:45.857Z	DEBUG	cluster-api.CAPIResource	Deleting	{"ClusterResourceSet": "calico-cni-installation-kind-kare", "Namespace": "default"}
2023-02-18T03:47:45.959Z	DEBUG	cluster-api.CAPIResource	Deleting	{"Cluster": "kind-kare", "Namespace": "default"}
2023-02-18T03:47:46.006Z	DEBUG	cluster-api.CAPIResource	Resuming the target ClusterClasses
2023-02-18T03:47:46.006Z	DEBUG	cluster-api.CAPIResource	Resuming the target cluster
```

which shows that `Move` operation can work now.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
