### PR TITLE
:bug: [cherrypick] Set nofile ulimit for loadbalancer container

### DIFF
--- a/test/go.mod
+++ b/test/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/docker/docker v20.10.21+incompatible
 	github.com/docker/go-connections v0.4.0
+	github.com/docker/go-units v0.4.0
 	github.com/flatcar/ignition v0.36.2
 	github.com/go-logr/logr v1.2.3
 	github.com/onsi/ginkgo/v2 v2.6.0
@@ -48,7 +49,6 @@ require (
 	github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/docker/distribution v2.8.1+incompatible // indirect
-	github.com/docker/go-units v0.4.0 // indirect
 	github.com/drone/envsubst/v2 v2.0.0-20210730161058-179042472c46 // indirect
 	github.com/emicklei/go-restful/v3 v3.9.0 // indirect
 	github.com/evanphx/json-patch v5.6.0+incompatible // indirect

--- a/test/infrastructure/container/docker.go
+++ b/test/infrastructure/container/docker.go
@@ -389,6 +389,7 @@ func (d *dockerRuntime) RunContainer(ctx context.Context, runConfig *RunContaine
 		Tmpfs:         runConfig.Tmpfs,
 		PortBindings:  nat.PortMap{},
 		RestartPolicy: dockercontainer.RestartPolicy{Name: restartPolicy},
+		Resources:     runConfig.Resources,
 	}
 	networkConfig := network.NetworkingConfig{}
 

--- a/test/infrastructure/container/interface.go
+++ b/test/infrastructure/container/interface.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"io"
 
+	dockercontainer "github.com/docker/docker/api/types/container"
+
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 )
 
@@ -98,6 +100,8 @@ type RunContainerInput struct {
 	// RestartPolicy to use for the container.
 	// If not set, defaults to "unless-stopped".
 	RestartPolicy string
+	// Resource limits and settings for the container.
+	Resources dockercontainer.Resources
 }
 
 // ExecContainerInput contains values for running exec on a container.


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Cherrypick https://github.com/kubernetes-sigs/cluster-api/pull/7344 to fix Docker provider HAProxy LB consuming too much memory.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
