### PR TITLE
:warning: chore: cherry pick changes from 1.3.3 to 1.4.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,10 +28,27 @@ jobs:
           go-version: ${{ env.go_version }}
       - name: generate release artifacts
         run: |
+          export REGISTRY=docker.io/mesosphere
+          export PROD_REGISTRY=$REGISTRY
+          export STAGING_REGISTRY=$REGISTRY
+          export TAG=${{ env.RELEASE_TAG }}
           make release
       - name: Release
         uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # tag=v1
         with:
           draft: true
           files: out/*
-          body: "TODO: Copy release notes shared by the comms team"
+          body_path: _releasenotes/${{ env.RELEASE_TAG }}.md
+      - name: Login to Dockerhub Registry
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.NEXUS_USERNAME }}
+          password: ${{ secrets.NEXUS_PASSWORD }}
+      - name: Build and push docker images
+        run: |
+          export REGISTRY=docker.io/mesosphere
+          export PROD_REGISTRY=$REGISTRY
+          export STAGING_REGISTRY=$REGISTRY
+          export TAG=${{ env.RELEASE_TAG }}
+          make ALL_ARCH="amd64 arm64" docker-build-all
+          make ALL_ARCH="amd64 arm64" docker-push-all

--- a/api/v1beta1/cluster_types.go
+++ b/api/v1beta1/cluster_types.go
@@ -34,6 +34,9 @@ const (
 	// ClusterFinalizer is the finalizer used by the cluster controller to
 	// cleanup the cluster resources when a Cluster is being deleted.
 	ClusterFinalizer = "cluster.cluster.x-k8s.io"
+
+	// ClusterKind represents the Kind of Cluster.
+	ClusterKind = "Cluster"
 )
 
 // ANCHOR: ClusterSpec

--- a/api/v1beta1/clusterclass_types.go
+++ b/api/v1beta1/clusterclass_types.go
@@ -25,6 +25,9 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
+// ClusterClassKind represents the Kind of ClusterClass.
+const ClusterClassKind = "ClusterClass"
+
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:path=clusterclasses,shortName=cc,scope=Namespaced,categories=cluster-api
 // +kubebuilder:storageversion

--- a/cmd/clusterctl/client/cluster/mover.go
+++ b/cmd/clusterctl/client/cluster/mover.go
@@ -27,6 +27,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -41,10 +42,13 @@ import (
 	"sigs.k8s.io/cluster-api/util/yaml"
 )
 
+// ResourceMutatorFunc holds the type for mutators to be applied on resources during a move operation.
+type ResourceMutatorFunc func(u *unstructured.Unstructured) error
+
 // ObjectMover defines methods for moving Cluster API objects to another management cluster.
 type ObjectMover interface {
 	// Move moves all the Cluster API objects existing in a namespace (or from all the namespaces if empty) to a target management cluster.
-	Move(namespace string, toCluster Client, dryRun bool) error
+	Move(namespace string, toCluster Client, dryRun bool, mutators ...ResourceMutatorFunc) error
 
 	// ToDirectory writes all the Cluster API objects existing in a namespace (or from all the namespaces if empty) to a target directory.
 	ToDirectory(namespace string, directory string) error
@@ -63,7 +67,7 @@ type objectMover struct {
 // ensure objectMover implements the ObjectMover interface.
 var _ ObjectMover = &objectMover{}
 
-func (o *objectMover) Move(namespace string, toCluster Client, dryRun bool) error {
+func (o *objectMover) Move(namespace string, toCluster Client, dryRun bool, mutators ...ResourceMutatorFunc) error {
 	log := logf.Log
 	log.Info("Performing move...")
 	o.dryRun = dryRun
@@ -91,7 +95,7 @@ func (o *objectMover) Move(namespace string, toCluster Client, dryRun bool) erro
 		proxy = toCluster.Proxy()
 	}
 
-	return o.move(objectGraph, proxy)
+	return o.move(objectGraph, proxy, mutators...)
 }
 
 func (o *objectMover) ToDirectory(namespace string, directory string) error {
@@ -308,7 +312,7 @@ func getMachineObj(proxy Proxy, machine *node, machineObj *clusterv1.Machine) er
 }
 
 // Move moves all the Cluster API objects existing in a namespace (or from all the namespaces if empty) to a target management cluster.
-func (o *objectMover) move(graph *objectGraph, toProxy Proxy) error {
+func (o *objectMover) move(graph *objectGraph, toProxy Proxy, mutators ...ResourceMutatorFunc) error {
 	log := logf.Log
 
 	clusters := graph.getClusters()
@@ -328,11 +332,9 @@ func (o *objectMover) move(graph *objectGraph, toProxy Proxy) error {
 		return errors.Wrap(err, "error pausing ClusterClasses")
 	}
 
-	// Ensure all the expected target namespaces are in place before creating objects.
-	log.V(1).Info("Creating target namespaces, if missing")
-	if err := o.ensureNamespaces(graph, toProxy); err != nil {
-		return err
-	}
+	// Nb. DO NOT call ensureNamespaces at this point because:
+	// - namespace will be ensured to exist before creating the resource.
+	// - If it's done here, we might create a namespace that can end up unused on target cluster (due to mutators).
 
 	// Define the move sequence by processing the ownerReference chain, so we ensure that a Kubernetes object is moved only after its owners.
 	// The sequence is bases on object graph nodes, each one representing a Kubernetes object; nodes are grouped, so bulk of nodes can be moved in parallel. e.g.
@@ -344,10 +346,14 @@ func (o *objectMover) move(graph *objectGraph, toProxy Proxy) error {
 	// Create all objects group by group, ensuring all the ownerReferences are re-created.
 	log.Info("Creating objects in the target cluster")
 	for groupIndex := 0; groupIndex < len(moveSequence.groups); groupIndex++ {
-		if err := o.createGroup(moveSequence.getGroup(groupIndex), toProxy); err != nil {
+		if err := o.createGroup(moveSequence.getGroup(groupIndex), toProxy, mutators...); err != nil {
 			return err
 		}
 	}
+
+	// Nb. mutators used after this point (after creating the resources on target clusters) are mainly intended for
+	// using the right namespace to fetch the resource from the target cluster.
+	// mutators affecting non metadata fields are no-op after this point.
 
 	// Delete all objects group by group in reverse order.
 	log.Info("Deleting objects from the source cluster")
@@ -359,13 +365,13 @@ func (o *objectMover) move(graph *objectGraph, toProxy Proxy) error {
 
 	// Resume the ClusterClasses in the target management cluster, so the controllers start reconciling it.
 	log.V(1).Info("Resuming the target ClusterClasses")
-	if err := setClusterClassPause(toProxy, clusterClasses, false, o.dryRun); err != nil {
+	if err := setClusterClassPause(toProxy, clusterClasses, false, o.dryRun, mutators...); err != nil {
 		return errors.Wrap(err, "error resuming ClusterClasses")
 	}
 
 	// Reset the pause field on the Cluster object in the target management cluster, so the controllers start reconciling it.
 	log.V(1).Info("Resuming the target cluster")
-	return setClusterPause(toProxy, clusters, false, o.dryRun)
+	return setClusterPause(toProxy, clusters, false, o.dryRun, mutators...)
 }
 
 func (o *objectMover) toDirectory(graph *objectGraph, directory string) error {
@@ -532,7 +538,7 @@ func getMoveSequence(graph *objectGraph) *moveSequence {
 }
 
 // setClusterPause sets the paused field on nodes referring to Cluster objects.
-func setClusterPause(proxy Proxy, clusters []*node, value bool, dryRun bool) error {
+func setClusterPause(proxy Proxy, clusters []*node, value bool, dryRun bool, mutators ...ResourceMutatorFunc) error {
 	if dryRun {
 		return nil
 	}
@@ -553,7 +559,7 @@ func setClusterPause(proxy Proxy, clusters []*node, value bool, dryRun bool) err
 
 		// Nb. The operation is wrapped in a retry loop to make setClusterPause more resilient to unexpected conditions.
 		if err := retryWithExponentialBackoff(setClusterPauseBackoff, func() error {
-			return patchCluster(proxy, cluster, patch)
+			return patchCluster(proxy, cluster, patch, mutators...)
 		}); err != nil {
 			return errors.Wrapf(err, "error setting Cluster.Spec.Paused=%t", value)
 		}
@@ -562,7 +568,7 @@ func setClusterPause(proxy Proxy, clusters []*node, value bool, dryRun bool) err
 }
 
 // setClusterClassPause sets the paused annotation on nodes referring to ClusterClass objects.
-func setClusterClassPause(proxy Proxy, clusterclasses []*node, pause bool, dryRun bool) error {
+func setClusterClassPause(proxy Proxy, clusterclasses []*node, pause bool, dryRun bool, mutators ...ResourceMutatorFunc) error {
 	if dryRun {
 		return nil
 	}
@@ -580,7 +586,7 @@ func setClusterClassPause(proxy Proxy, clusterclasses []*node, pause bool, dryRu
 
 		// Nb. The operation is wrapped in a retry loop to make setClusterClassPause more resilient to unexpected conditions.
 		if err := retryWithExponentialBackoff(setClusterClassPauseBackoff, func() error {
-			return pauseClusterClass(proxy, clusterclass, pause)
+			return pauseClusterClass(proxy, clusterclass, pause, mutators...)
 		}); err != nil {
 			return errors.Wrapf(err, "error updating ClusterClass %s/%s", clusterclass.identity.Namespace, clusterclass.identity.Name)
 		}
@@ -589,19 +595,29 @@ func setClusterClassPause(proxy Proxy, clusterclasses []*node, pause bool, dryRu
 }
 
 // patchCluster applies a patch to a node referring to a Cluster object.
-func patchCluster(proxy Proxy, cluster *node, patch client.Patch) error {
+func patchCluster(proxy Proxy, n *node, patch client.Patch, mutators ...ResourceMutatorFunc) error {
 	cFrom, err := proxy.NewClient()
 	if err != nil {
 		return err
 	}
 
-	clusterObj := &clusterv1.Cluster{}
-	clusterObjKey := client.ObjectKey{
-		Namespace: cluster.identity.Namespace,
-		Name:      cluster.identity.Name,
+	// Since the patch has been generated already in caller of this function, the ONLY affect that mutators can have
+	// here is on namespace of the resource.
+	clusterObj, err := applyMutators(&clusterv1.Cluster{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       clusterv1.ClusterKind,
+			APIVersion: clusterv1.GroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      n.identity.Name,
+			Namespace: n.identity.Namespace,
+		},
+	}, mutators...)
+	if err != nil {
+		return err
 	}
 
-	if err := cFrom.Get(ctx, clusterObjKey, clusterObj); err != nil {
+	if err := cFrom.Get(ctx, client.ObjectKeyFromObject(clusterObj), clusterObj); err != nil {
 		return errors.Wrapf(err, "error reading Cluster %s/%s",
 			clusterObj.GetNamespace(), clusterObj.GetName())
 	}
@@ -614,18 +630,35 @@ func patchCluster(proxy Proxy, cluster *node, patch client.Patch) error {
 	return nil
 }
 
-func pauseClusterClass(proxy Proxy, n *node, pause bool) error {
+func pauseClusterClass(proxy Proxy, n *node, pause bool, mutators ...ResourceMutatorFunc) error {
 	cFrom, err := proxy.NewClient()
 	if err != nil {
 		return errors.Wrap(err, "error creating client")
 	}
 
-	// Get the ClusterClass from the server
-	clusterClass := &clusterv1.ClusterClass{}
-	clusterClassObjKey := client.ObjectKey{
-		Name:      n.identity.Name,
-		Namespace: n.identity.Namespace,
+	// Get a mutated copy of the ClusterClass to identify the target namespace.
+	// The ClusterClass could have been moved to a different namespace after the move.
+	mutatedClusterClass, err := applyMutators(&clusterv1.ClusterClass{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       clusterv1.ClusterClassKind,
+			APIVersion: clusterv1.GroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      n.identity.Name,
+			Namespace: n.identity.Namespace,
+		}}, mutators...)
+	if err != nil {
+		return err
 	}
+
+	clusterClass := &clusterv1.ClusterClass{}
+	// Construct an object key using the mutatedClusterClass reflecting any changes to the namespace.
+	clusterClassObjKey := client.ObjectKey{
+		Name:      mutatedClusterClass.GetName(),
+		Namespace: mutatedClusterClass.GetNamespace(),
+	}
+	// Get a copy of the ClusterClass.
+	// This will ensure that any other changes from the mutator are ignored here as we work with a fresh copy of the cluster class.
 	if err := cFrom.Get(ctx, clusterClassObjKey, clusterClass); err != nil {
 		return errors.Wrapf(err, "error reading ClusterClass %s/%s", n.identity.Namespace, n.identity.Name)
 	}
@@ -735,7 +768,7 @@ func (o *objectMover) ensureNamespace(toProxy Proxy, namespace string) error {
 		return err
 	}
 
-	// If the namespace does not exists, create it.
+	// If the namespace does not exist, create it.
 	ns = &corev1.Namespace{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "v1",
@@ -753,15 +786,18 @@ func (o *objectMover) ensureNamespace(toProxy Proxy, namespace string) error {
 }
 
 // createGroup creates all the Kubernetes objects into the target management cluster corresponding to the object graph nodes in a moveGroup.
-func (o *objectMover) createGroup(group moveGroup, toProxy Proxy) error {
+func (o *objectMover) createGroup(group moveGroup, toProxy Proxy, mutators ...ResourceMutatorFunc) error {
 	createTargetObjectBackoff := newWriteBackoff()
 	errList := []error{}
 
+	// Maintain a cache of namespaces that have been verified to already exist.
+	// Nb. This prevents us from making repetitive (and expensive) calls in listing all namespaces to ensure a namespace exists before creating a resource.
+	existingNamespaces := sets.New[string]()
 	for _, nodeToCreate := range group {
 		// Creates the Kubernetes object corresponding to the nodeToCreate.
 		// Nb. The operation is wrapped in a retry loop to make move more resilient to unexpected conditions.
 		err := retryWithExponentialBackoff(createTargetObjectBackoff, func() error {
-			return o.createTargetObject(nodeToCreate, toProxy)
+			return o.createTargetObject(nodeToCreate, toProxy, mutators, existingNamespaces)
 		})
 		if err != nil {
 			errList = append(errList, err)
@@ -820,7 +856,7 @@ func (o *objectMover) restoreGroup(group moveGroup, toProxy Proxy) error {
 }
 
 // createTargetObject creates the Kubernetes object in the target Management cluster corresponding to the object graph node, taking care of restoring the OwnerReference with the owner nodes, if any.
-func (o *objectMover) createTargetObject(nodeToCreate *node, toProxy Proxy) error {
+func (o *objectMover) createTargetObject(nodeToCreate *node, toProxy Proxy, mutators []ResourceMutatorFunc, existingNamespaces sets.Set[string]) error {
 	log := logf.Log
 	log.V(1).Info("Creating", nodeToCreate.identity.Kind, nodeToCreate.identity.Name, "Namespace", nodeToCreate.identity.Namespace)
 
@@ -853,7 +889,7 @@ func (o *objectMover) createTargetObject(nodeToCreate *node, toProxy Proxy) erro
 	// Removes current OwnerReferences
 	obj.SetOwnerReferences(nil)
 
-	// Rebuild the owne reference chain
+	// Rebuild the owner reference chain
 	o.buildOwnerChain(obj, nodeToCreate)
 
 	// FIXME Workaround for https://github.com/kubernetes/kubernetes/issues/32220. Remove when the issue is fixed.
@@ -868,6 +904,17 @@ func (o *objectMover) createTargetObject(nodeToCreate *node, toProxy Proxy) erro
 		return err
 	}
 
+	obj, err = applyMutators(obj, mutators...)
+	if err != nil {
+		return err
+	}
+	// Applying mutators MAY change the namespace, so ensure the namespace exists before creating the resource.
+	if !nodeToCreate.isGlobal && !existingNamespaces.Has(obj.GetNamespace()) {
+		if err = o.ensureNamespace(toProxy, obj.GetNamespace()); err != nil {
+			return err
+		}
+		existingNamespaces.Insert(obj.GetNamespace())
+	}
 	oldManagedFields := obj.GetManagedFields()
 	if err := cTo.Create(ctx, obj); err != nil {
 		if !apierrors.IsAlreadyExists(err) {
@@ -1187,4 +1234,23 @@ func patchTopologyManagedFields(ctx context.Context, oldManagedFields []metav1.M
 			obj.GroupVersionKind(), obj.GetNamespace(), obj.GetName())
 	}
 	return nil
+}
+
+func applyMutators(object client.Object, mutators ...ResourceMutatorFunc) (*unstructured.Unstructured, error) {
+	if object == nil {
+		return nil, nil
+	}
+	u := &unstructured.Unstructured{}
+	to, err := runtime.DefaultUnstructuredConverter.ToUnstructured(object)
+	if err != nil {
+		return nil, err
+	}
+	u.SetUnstructuredContent(to)
+	for _, mutator := range mutators {
+		if err := mutator(u); err != nil {
+			return nil, errors.Wrapf(err, "error applying resource mutator to %q %s/%s",
+				u.GroupVersionKind(), object.GetNamespace(), object.GetName())
+		}
+	}
+	return u, nil
 }

--- a/cmd/clusterctl/client/move.go
+++ b/cmd/clusterctl/client/move.go
@@ -38,6 +38,10 @@ type MoveOptions struct {
 	// namespace will be used.
 	Namespace string
 
+	// ExperimentalResourceMutatorFn accepts any number of resource mutator functions that are applied on all resources being moved.
+	// This is an experimental feature and is exposed only from the library and not (yet) through the CLI.
+	ExperimentalResourceMutators []cluster.ResourceMutatorFunc
+
 	// FromDirectory apply configuration from directory.
 	FromDirectory string
 
@@ -94,7 +98,7 @@ func (c *clusterctlClient) move(options MoveOptions) error {
 		}
 	}
 
-	return fromCluster.ObjectMover().Move(options.Namespace, toCluster, options.DryRun)
+	return fromCluster.ObjectMover().Move(options.Namespace, toCluster, options.DryRun, options.ExperimentalResourceMutators...)
 }
 
 func (c *clusterctlClient) fromDirectory(options MoveOptions) error {

--- a/cmd/clusterctl/client/move_test.go
+++ b/cmd/clusterctl/client/move_test.go
@@ -298,7 +298,7 @@ type fakeObjectMover struct {
 	fromDirectoryErr error
 }
 
-func (f *fakeObjectMover) Move(_ string, _ cluster.Client, _ bool) error {
+func (f *fakeObjectMover) Move(_ string, _ cluster.Client, _ bool, _ ...cluster.ResourceMutatorFunc) error {
 	return f.moveErr
 }
 

--- a/config/crd/bases/addons.cluster.x-k8s.io_clusterresourcesets.yaml
+++ b/config/crd/bases/addons.cluster.x-k8s.io_clusterresourcesets.yaml
@@ -112,6 +112,7 @@ spec:
                   Defaults to ApplyOnce. This field is immutable.
                 enum:
                 - ApplyOnce
+                - ApplyAlways
                 type: string
             required:
             - clusterSelector
@@ -438,6 +439,7 @@ spec:
                   Defaults to ApplyOnce. This field is immutable.
                 enum:
                 - ApplyOnce
+                - ApplyAlways
                 - Reconcile
                 type: string
             required:

--- a/exp/addons/api/v1beta1/clusterresourceset_types.go
+++ b/exp/addons/api/v1beta1/clusterresourceset_types.go
@@ -46,7 +46,7 @@ type ClusterResourceSetSpec struct {
 	Resources []ResourceRef `json:"resources,omitempty"`
 
 	// Strategy is the strategy to be used during applying resources. Defaults to ApplyOnce. This field is immutable.
-	// +kubebuilder:validation:Enum=ApplyOnce;Reconcile
+	// +kubebuilder:validation:Enum=ApplyOnce;ApplyAlways;Reconcile
 	// +optional
 	Strategy string `json:"strategy,omitempty"`
 }
@@ -83,6 +83,9 @@ const (
 	// ClusterResourceSetStrategyReconcile reapplies the resources managed by a ClusterResourceSet
 	// if their normalized hash changes.
 	ClusterResourceSetStrategyReconcile ClusterResourceSetStrategy = "Reconcile"
+	// ClusterResourceSetStrategyApplyAlways is the strategy where changes to the ClusterResourceSet
+	// are applied always if they exist already in clusters or created if they do not.
+	ClusterResourceSetStrategyApplyAlways ClusterResourceSetStrategy = "ApplyAlways"
 )
 
 // SetTypedStrategy sets the Strategy field to the string representation of ClusterResourceSetStrategy.

--- a/exp/addons/internal/controllers/clusterresourceset_controller.go
+++ b/exp/addons/internal/controllers/clusterresourceset_controller.go
@@ -222,7 +222,7 @@ func (r *ClusterResourceSetReconciler) getClustersByClusterResourceSetSelector(c
 		return nil, errors.Wrap(err, "failed to list clusters")
 	}
 
-	clusters := make([]*clusterv1.Cluster, 0)
+	clusters := []*clusterv1.Cluster{}
 	for i := range clusterList.Items {
 		c := &clusterList.Items[i]
 		if c.DeletionTimestamp.IsZero() {
@@ -417,7 +417,7 @@ func (r *ClusterResourceSetReconciler) ensureResourceOwnerRef(ctx context.Contex
 
 // clusterToClusterResourceSet is mapper function that maps clusters to ClusterResourceSet.
 func (r *ClusterResourceSetReconciler) clusterToClusterResourceSet(o client.Object) []ctrl.Request {
-	result := make([]ctrl.Request, 0)
+	result := []ctrl.Request{}
 
 	cluster, ok := o.(*clusterv1.Cluster)
 	if !ok {
@@ -455,7 +455,7 @@ func (r *ClusterResourceSetReconciler) clusterToClusterResourceSet(o client.Obje
 
 // resourceToClusterResourceSet is mapper function that maps resources to ClusterResourceSet.
 func (r *ClusterResourceSetReconciler) resourceToClusterResourceSet(o client.Object) []ctrl.Request {
-	result := make([]ctrl.Request, 0)
+	result := []ctrl.Request{}
 
 	// Add all ClusterResourceSet owners.
 	for _, owner := range o.GetOwnerReferences() {

--- a/exp/addons/internal/controllers/clusterresourceset_controller.go
+++ b/exp/addons/internal/controllers/clusterresourceset_controller.go
@@ -222,7 +222,7 @@ func (r *ClusterResourceSetReconciler) getClustersByClusterResourceSetSelector(c
 		return nil, errors.Wrap(err, "failed to list clusters")
 	}
 
-	clusters := []*clusterv1.Cluster{}
+	clusters := make([]*clusterv1.Cluster, 0)
 	for i := range clusterList.Items {
 		c := &clusterList.Items[i]
 		if c.DeletionTimestamp.IsZero() {
@@ -417,7 +417,7 @@ func (r *ClusterResourceSetReconciler) ensureResourceOwnerRef(ctx context.Contex
 
 // clusterToClusterResourceSet is mapper function that maps clusters to ClusterResourceSet.
 func (r *ClusterResourceSetReconciler) clusterToClusterResourceSet(o client.Object) []ctrl.Request {
-	result := []ctrl.Request{}
+	result := make([]ctrl.Request, 0)
 
 	cluster, ok := o.(*clusterv1.Cluster)
 	if !ok {
@@ -455,7 +455,7 @@ func (r *ClusterResourceSetReconciler) clusterToClusterResourceSet(o client.Obje
 
 // resourceToClusterResourceSet is mapper function that maps resources to ClusterResourceSet.
 func (r *ClusterResourceSetReconciler) resourceToClusterResourceSet(o client.Object) []ctrl.Request {
-	result := []ctrl.Request{}
+	result := make([]ctrl.Request, 0)
 
 	// Add all ClusterResourceSet owners.
 	for _, owner := range o.GetOwnerReferences() {

--- a/exp/addons/internal/controllers/clusterresourceset_controller_test.go
+++ b/exp/addons/internal/controllers/clusterresourceset_controller_test.go
@@ -1177,7 +1177,7 @@ data:
 			},
 		}
 
-		// update the configmap data
+		// update the secret data
 		t.Log("Updating the secret resource")
 		g.Expect(env.Update(ctx, secretUpdate)).To(Succeed())
 
@@ -1198,6 +1198,188 @@ data:
 			// only one resource is applied
 			resource := bindings[0].Resources[0]
 			return resource.Hash != oldHash
+		}, timeout).Should(BeTrue())
+	})
+
+	t.Run("Should create ClusterResourceSet with strategy 'AlwaysApply' and reconcile configmap only once if data has not changed", func(t *testing.T) {
+		g := NewWithT(t)
+		ns := setup(t, g)
+		defer teardown(t, g, ns)
+
+		t.Log("Updating the cluster with labels")
+		testCluster.SetLabels(labels)
+		g.Expect(env.Update(ctx, testCluster)).To(Succeed())
+
+		clusterResourceSetInstance := &addonsv1.ClusterResourceSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      clusterResourceSetName,
+				Namespace: ns.Name,
+			},
+			Spec: addonsv1.ClusterResourceSetSpec{
+				ClusterSelector: metav1.LabelSelector{
+					MatchLabels: labels,
+				},
+				Strategy:  "ApplyAlways",
+				Resources: []addonsv1.ResourceRef{{Name: configmapName, Kind: "ConfigMap"}},
+			},
+		}
+		// Create the ClusterResourceSet.
+		g.Expect(env.Create(ctx, clusterResourceSetInstance)).To(Succeed())
+
+		// Wait until ClusterResourceSetBinding is created for the Cluster
+		clusterResourceSetBindingKey := client.ObjectKey{
+			Namespace: testCluster.Namespace,
+			Name:      testCluster.Name,
+		}
+
+		// Wait until ClusterResourceSetBinding is created for the Cluster
+		t.Log("Waiting for the ClusterResourceSetBinding to be created")
+		oldHash := ""
+		var oldLastAppliedTime *metav1.Time
+		g.Eventually(func() bool {
+			binding := &addonsv1.ClusterResourceSetBinding{}
+			err := env.Get(ctx, clusterResourceSetBindingKey, binding)
+			if err != nil {
+				return false
+			}
+
+			bindings := binding.Spec.Bindings
+			// should only have one binding
+			if len(bindings) != 1 {
+				return false
+			}
+
+			// only one resource is applied
+			resource := bindings[0].Resources[0]
+			oldHash = resource.Hash
+			oldLastAppliedTime = resource.LastAppliedTime
+			return resource.Applied
+		}, timeout).Should(BeTrue())
+
+		// Get configmap obj, update the configmap
+		cmKey := client.ObjectKey{
+			Namespace: ns.Name,
+			Name:      configmapName,
+		}
+		cm := &corev1.ConfigMap{}
+		g.Expect(env.Get(ctx, cmKey, cm)).To(Succeed())
+
+		cm.Labels = map[string]string{"foo": "bar"}
+
+		// The CRS controller writes a lastAppliedTime field, which is of type metav1.Time. The precision at most a
+		// second. Therefore, if the controller re-applies the resource twice within one second, the lastAppliedTime
+		// value is unlikely to change. Our test below compares the lastAppliedTime values of two reconciles, so we wait
+		// to prevent the reconciles from running within the same second. Related issue: https://issues.k8s.io/15262
+		t.Log("Letting some time pass before updating the resource, so that lastAppliedTime will be different.")
+		time.Sleep(10 * time.Second)
+
+		// update the configmap data
+		t.Log("Updating the configmap resource")
+		g.Expect(env.Update(ctx, cm)).To(Succeed())
+
+		t.Log("Verifying that resource is not re-applied over a period of time.")
+		g.Consistently(func() bool {
+			binding := &addonsv1.ClusterResourceSetBinding{}
+			err := env.Get(ctx, clusterResourceSetBindingKey, binding)
+			if err != nil {
+				return false
+			}
+
+			bindings := binding.Spec.Bindings
+			// only one resource is applied
+			resource := bindings[0].Resources[0]
+			return oldHash == resource.Hash && oldLastAppliedTime.Equal(resource.LastAppliedTime)
+		}, timeout).Should(BeTrue())
+	})
+
+	t.Run("Should create ClusterResourceSet with strategy 'AlwaysApply' and reconcile secrets only once if data has not changed", func(t *testing.T) {
+		g := NewWithT(t)
+		ns := setup(t, g)
+		defer teardown(t, g, ns)
+
+		t.Log("Updating the cluster with labels")
+		testCluster.SetLabels(labels)
+		g.Expect(env.Update(ctx, testCluster)).To(Succeed())
+
+		clusterResourceSetInstance := &addonsv1.ClusterResourceSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      clusterResourceSetName,
+				Namespace: ns.Name,
+			},
+			Spec: addonsv1.ClusterResourceSetSpec{
+				ClusterSelector: metav1.LabelSelector{
+					MatchLabels: labels,
+				},
+				Strategy:  "ApplyAlways",
+				Resources: []addonsv1.ResourceRef{{Name: secretName, Kind: "Secret"}},
+			},
+		}
+		// Create the ClusterResourceSet.
+		g.Expect(env.Create(ctx, clusterResourceSetInstance)).To(Succeed())
+
+		// Wait until ClusterResourceSetBinding is created for the Cluster
+		clusterResourceSetBindingKey := client.ObjectKey{
+			Namespace: testCluster.Namespace,
+			Name:      testCluster.Name,
+		}
+
+		t.Log("Waiting for the ClusterResourceSetBinding to be created")
+		oldHash := ""
+		var oldLastAppliedTime *metav1.Time
+		g.Eventually(func() bool {
+			binding := &addonsv1.ClusterResourceSetBinding{}
+			err := env.Get(ctx, clusterResourceSetBindingKey, binding)
+			if err != nil {
+				return false
+			}
+
+			bindings := binding.Spec.Bindings
+			// should only have one binding
+			if len(bindings) != 1 {
+				return false
+			}
+
+			// only one resource is applied
+			resource := bindings[0].Resources[0]
+			oldHash = resource.Hash
+			oldLastAppliedTime = resource.LastAppliedTime
+			return resource.Applied
+		}, timeout).Should(BeTrue())
+
+		secretKey := client.ObjectKey{
+			Namespace: ns.Name,
+			Name:      secretName,
+		}
+		secret := &corev1.Secret{}
+		g.Expect(env.Get(ctx, secretKey, secret)).To(Succeed())
+
+		// Overwrite the Secret labels to cause the ClusterResourceSet controller to reconcile any CRS that references
+		// the Secret.
+		secret.Labels = map[string]string{"foo": "bar"}
+
+		// The CRS controller writes a lastAppliedTime field, which is of type metav1.Time. The precision at most a
+		// second. Therefore, if the controller re-applies the resource twice within one second, the lastAppliedTime
+		// value is unlikely to change. Our test below compares the lastAppliedTime values of two reconciles, so we wait
+		// to prevent the reconciles from running within the same second. Related issue: https://issues.k8s.io/15262
+		t.Log("Letting some time pass before updating the resource, so that lastAppliedTime will be different.")
+		time.Sleep(10 * time.Second)
+
+		// update the secrete, but not its data
+		t.Log("Updating the secret resource")
+		g.Expect(env.Update(ctx, secret)).To(Succeed())
+
+		t.Log("Verifying that resource is not re-applied over a period of time.")
+		g.Consistently(func() bool {
+			binding := &addonsv1.ClusterResourceSetBinding{}
+			err := env.Get(ctx, clusterResourceSetBindingKey, binding)
+			if err != nil {
+				return false
+			}
+
+			bindings := binding.Spec.Bindings
+			// only one resource is applied
+			resource := bindings[0].Resources[0]
+			return oldHash == resource.Hash && oldLastAppliedTime.Equal(resource.LastAppliedTime)
 		}, timeout).Should(BeTrue())
 	})
 }

--- a/exp/addons/internal/controllers/clusterresourceset_controller_test.go
+++ b/exp/addons/internal/controllers/clusterresourceset_controller_test.go
@@ -1271,7 +1271,7 @@ data:
 		// value is unlikely to change. Our test below compares the lastAppliedTime values of two reconciles, so we wait
 		// to prevent the reconciles from running within the same second. Related issue: https://issues.k8s.io/15262
 		t.Log("Letting some time pass before updating the resource, so that lastAppliedTime will be different.")
-		time.Sleep(10 * time.Second)
+		time.Sleep(2 * time.Second)
 
 		// update the configmap data
 		t.Log("Updating the configmap resource")
@@ -1362,7 +1362,7 @@ data:
 		// value is unlikely to change. Our test below compares the lastAppliedTime values of two reconciles, so we wait
 		// to prevent the reconciles from running within the same second. Related issue: https://issues.k8s.io/15262
 		t.Log("Letting some time pass before updating the resource, so that lastAppliedTime will be different.")
-		time.Sleep(10 * time.Second)
+		time.Sleep(2 * time.Second)
 
 		// update the secrete, but not its data
 		t.Log("Updating the secret resource")

--- a/exp/addons/internal/controllers/clusterresourceset_scope.go
+++ b/exp/addons/internal/controllers/clusterresourceset_scope.go
@@ -82,6 +82,8 @@ func newResourceReconcileScope(
 		return &reconcileApplyOnceScope{base}
 	case addonsv1.ClusterResourceSetStrategyReconcile:
 		return &reconcileStrategyScope{base}
+	case addonsv1.ClusterResourceSetStrategyApplyAlways:
+		return &reconcileStrategyScope{base}
 	default:
 		return nil
 	}

--- a/test/go.mod
+++ b/test/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/docker/docker v20.10.21+incompatible
 	github.com/docker/go-connections v0.4.0
+	github.com/docker/go-units v0.4.0
 	github.com/flatcar/ignition v0.36.2
 	github.com/go-logr/logr v1.2.3
 	github.com/onsi/ginkgo/v2 v2.9.2
@@ -47,7 +48,6 @@ require (
 	github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/docker/distribution v2.8.1+incompatible // indirect
-	github.com/docker/go-units v0.4.0 // indirect
 	github.com/drone/envsubst/v2 v2.0.0-20210730161058-179042472c46 // indirect
 	github.com/emicklei/go-restful/v3 v3.9.0 // indirect
 	github.com/evanphx/json-patch v5.6.0+incompatible // indirect

--- a/test/infrastructure/container/docker.go
+++ b/test/infrastructure/container/docker.go
@@ -397,6 +397,7 @@ func (d *dockerRuntime) RunContainer(ctx context.Context, runConfig *RunContaine
 		PortBindings:  nat.PortMap{},
 		RestartPolicy: dockercontainer.RestartPolicy{Name: restartPolicy, MaximumRetryCount: restartMaximumRetryCount},
 		Init:          pointer.Bool(false),
+		Resources:     runConfig.Resources,
 	}
 	networkConfig := network.NetworkingConfig{}
 

--- a/test/infrastructure/container/interface.go
+++ b/test/infrastructure/container/interface.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"io"
 
+	dockercontainer "github.com/docker/docker/api/types/container"
+
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 )
 
@@ -98,6 +100,8 @@ type RunContainerInput struct {
 	// RestartPolicy to use for the container.
 	// If not set, defaults to "unless-stopped".
 	RestartPolicy string
+	// Resource limits and settings for the container.
+	Resources dockercontainer.Resources
 }
 
 // ExecContainerInput contains values for running exec on a container.

--- a/test/infrastructure/docker/internal/docker/kind_manager.go
+++ b/test/infrastructure/docker/internal/docker/kind_manager.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"net"
 
+	dockercontainer "github.com/docker/docker/api/types/container"
+	"github.com/docker/go-units"
 	"github.com/pkg/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/kind/pkg/apis/config/v1alpha4"
@@ -52,6 +54,7 @@ type nodeCreateOpts struct {
 	PortMappings []v1alpha4.PortMapping
 	Labels       map[string]string
 	IPFamily     clusterv1.ClusterIPFamily
+	Resources    dockercontainer.Resources
 }
 
 // CreateControlPlaneNode will create a new control plane container.
@@ -116,7 +119,6 @@ func (m *Manager) CreateExternalLoadBalancerNode(ctx context.Context, name, imag
 		}
 		port = p
 	}
-
 	// load balancer port mapping
 	portMappings := []v1alpha4.PortMapping{{
 		ListenAddress: listenAddress,
@@ -124,12 +126,25 @@ func (m *Manager) CreateExternalLoadBalancerNode(ctx context.Context, name, imag
 		ContainerPort: ControlPlanePort,
 		Protocol:      v1alpha4.PortMappingProtocolTCP,
 	}}
+
+	// load balancer resource limits
+	resources := dockercontainer.Resources{
+		Ulimits: []*units.Ulimit{
+			{
+				Name: "nofile",
+				Soft: 65536,
+				Hard: 65536,
+			},
+		},
+	}
+
 	createOpts := &nodeCreateOpts{
 		Name:         name,
 		Image:        image,
 		ClusterName:  clusterName,
 		Role:         constants.ExternalLoadBalancerNodeRoleValue,
 		PortMappings: portMappings,
+		Resources:    resources,
 	}
 	node, err := createNode(ctx, createOpts)
 	if err != nil {
@@ -168,7 +183,8 @@ func createNode(ctx context.Context, opts *nodeCreateOpts) (*types.Node, error) 
 			"/tmp": "", // various things depend on working /tmp
 			"/run": "", // systemd wants a writable /run
 		},
-		IPFamily: opts.IPFamily,
+		Resources: opts.Resources,
+		IPFamily:  opts.IPFamily,
 	}
 	if opts.Role == constants.ControlPlaneNodeRoleValue {
 		runOptions.EnvironmentVars = map[string]string{


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Following convention of https://github.com/mesosphere/cluster-api/pull/13

Desired diff https://github.com/kubernetes-sigs/cluster-api/compare/v1.3.3...mesosphere:cluster-api:v1.3.3-d2iq.2

Address https://d2iq.atlassian.net/browse/D2IQ-96736

#### Commits with manual conflict resolution

2daeb1cd1396b52a038fb43d062fe4747164869e - Resolved conflicts by reusing the same helpers for `Reconcile` and `ApplyAlways` strategies. Both values use same helpers.
2daeb1cd1396b52a038fb43d062fe4747164869e, 7a078fa87d363622c9658cf39c622c1ffe135d8a, and 12657ebb85c29ce1200cae5aa222cac35180f7de are squashed together to keep commits more contextual
2edb110f82edd05d605ee573ffa0f96c7c2ed1f1 - essentially dropped this commit as we can reuse the `Reconcile` strategy. There were some refactoring around helpers which were just code resturcturing with no functional impact, I adopted the upstream conventions to make future sync to upstream easier.
292b58c600f70692058b38cd56ff80aa4da52aef and 95e594fcbaedec1ff531cd20f8bcbaf82ec88b6d are squashed

#### Dropped commits
2edb110f82edd05d605ee573ffa0f96c7c2ed1f1 - no longer needed.
f632d09034b9719d37311dea4e5cd3f215022b3b - no longer needed.
df752366d2e119f4104ee9a9e260aab103f1b00b - no longer needed (tests passed without this diff).
1f41ac7e937752625862af75dc9a6f8aa501ea9a - no longer needed.
967896fdf58a77a349a707b3356f268dc350d494 - no longer needed.
13d66294bd57c8bcee49e22630e3a1f5d3f54af7 - helpers are no longer used.
7411fb6052f7105828a9e42b90ae3a013048c850 - no longer relevant
ce2ee611b9987e4f6fa6330732846a411ca78fd4 - while resolving conflicts in 2edb110f82edd05d605ee573ffa0f96c7c2ed1f1 i chose to adopt upstream conventions which means this commit is no longer needed.
f1f875a76b4224baefda3e8b1015d10e6249cf09 - no longer needed
00d89a1b0794737620609420a4c7ec3913e2b616 - dropped it in favor of applying changes from https://github.com/kubernetes-sigs/cluster-api/pull/7966
e6e64e8c2f3b03fb8c0cea5cf8214a81e61e610b - is no longer needed as the image is bumped upstream. we can pin a new image if issue resurfaces (or some other issue occurs).

#### New commits that are neither cherry picked nor present upstream
applied commits from https://github.com/kubernetes-sigs/cluster-api/pull/7966 (squashed)

Tested this locally to bring up a konvoy cluster and all the functionality seem to be working as expected.

```
➜  k get pods -n capi-kubeadm-bootstrap-system -oyaml | grep "image:"
      image: docker.io/takirala/kubeadm-bootstrap-controller-amd64:dev
      image: docker.io/takirala/kubeadm-bootstrap-controller-amd64:dev
➜  k get pods -n capi-kubeadm-control-plane-system -oyaml | grep "image:"
      image: docker.io/takirala/kubeadm-control-plane-controller-amd64:dev
      image: docker.io/takirala/kubeadm-control-plane-controller-amd64:dev
➜  k get cluster -A                                                      
NAMESPACE   NAME         PHASE         AGE   VERSION
takirala    takiapr120   Provisioned   53s   
➜   k get pods -A
NAMESPACE                           NAME                                                                 READY   STATUS    RESTARTS      AGE
calico-system                       calico-kube-controllers-6bb86c78b4-db5vr                             1/1     Running   0             19m
calico-system                       calico-node-r6qd7                                                    1/1     Running   0             19m
calico-system                       calico-node-zgn6c                                                    1/1     Running   0             19m
calico-system                       calico-typha-9d4d8f88f-ckmzl                                         1/1     Running   0             19m
calico-system                       csi-node-driver-58f9l                                                2/2     Running   0             19m
calico-system                       csi-node-driver-cghhs                                                2/2     Running   0             19m
capa-system                         capa-controller-manager-6b79c7c4d5-l5z5k                             1/1     Running   0             17m
capg-system                         capg-controller-manager-6cb46f7677-t5vdn                             1/1     Running   0             17m
capi-kubeadm-bootstrap-system       capi-kubeadm-bootstrap-controller-manager-7d98d5b4d5-wv5ml           1/1     Running   0             5m56s
capi-kubeadm-control-plane-system   capi-kubeadm-control-plane-controller-manager-65bb6df8b5-9gthw       1/1     Running   0             17m
capi-system                         capi-controller-manager-75796bb7d4-gv4gq                             1/1     Running   0             17m
cappp-system                        cappp-controller-manager-556d5c568-dfnxz                             1/1     Running   0             17m
capv-system                         capv-controller-manager-bdd598bc8-sx4bc                              1/1     Running   0             17m
capz-system                         capz-controller-manager-64557d59b4-6zm96                             1/1     Running   0             17m
capz-system                         capz-nmi-xkhtt                                                       1/1     Running   0             17m
cert-manager                        cert-manager-57b6545568-cs76r                                        1/1     Running   0             18m
cert-manager                        cert-manager-cainjector-56f5c49f7d-hnklx                             1/1     Running   0             18m
cert-manager                        cert-manager-webhook-7f94d496bb-fhwnf                                1/1     Running   0             18m
kube-system                         cluster-autoscaler-5d97dc4697-vsz8v                                  1/1     Running   0             20m
kube-system                         coredns-787d4945fb-5gcjd                                             1/1     Running   0             20m
kube-system                         coredns-787d4945fb-nkcrb                                             1/1     Running   0             20m
kube-system                         ebs-csi-controller-6b9f78d499-ltfwj                                  6/6     Running   0             20m
kube-system                         ebs-csi-controller-6b9f78d499-nq97z                                  6/6     Running   0             20m
kube-system                         ebs-csi-node-5qb8x                                                   3/3     Running   0             19m
kube-system                         ebs-csi-node-xt5qx                                                   3/3     Running   0             20m
kube-system                         etcd-ip-10-0-121-225.us-west-2.compute.internal                      1/1     Running   0             20m
kube-system                         kube-apiserver-ip-10-0-121-225.us-west-2.compute.internal            1/1     Running   0             20m
kube-system                         kube-controller-manager-ip-10-0-121-225.us-west-2.compute.internal   1/1     Running   0             20m
kube-system                         kube-proxy-nvbfn                                                     1/1     Running   0             19m
kube-system                         kube-proxy-x6d8k                                                     1/1     Running   0             20m
kube-system                         kube-scheduler-ip-10-0-121-225.us-west-2.compute.internal            1/1     Running   0             20m
kube-system                         snapshot-controller-785847dd8b-6d9sd                                 1/1     Running   0             20m
kube-system                         snapshot-controller-785847dd8b-rs245                                 1/1     Running   0             20m
node-feature-discovery              node-feature-discovery-master-546f9ff77d-69694                       1/1     Running   0             20m
node-feature-discovery              node-feature-discovery-worker-cqxrq                                  1/1     Running   1 (18m ago)   18m
tigera-operator                     tigera-operator-7854d775f7-26tnd                                     1/1     Running   1 (19m ago)   20m
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
