### PR TITLE
🌱 chore: cherry pick changes from 1.5.1 to 1.5.3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,10 @@ jobs:
           go-version: ${{ env.go_version }}
       - name: generate release artifacts
         run: |
+          export REGISTRY=docker.io/mesosphere
+          export PROD_REGISTRY=$REGISTRY
+          export STAGING_REGISTRY=$REGISTRY
+          export TAG=${{ env.RELEASE_TAG }}
           make release
       - name: Release
         uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # tag=v1
@@ -35,3 +39,16 @@ jobs:
           draft: true
           files: out/*
           body: "TODO: Copy release notes shared by the comms team"
+      - name: Login to Dockerhub Registry
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.NEXUS_USERNAME }}
+          password: ${{ secrets.NEXUS_PASSWORD }}
+      - name: Build and push docker images
+        run: |
+          export REGISTRY=docker.io/mesosphere
+          export PROD_REGISTRY=$REGISTRY
+          export STAGING_REGISTRY=$REGISTRY
+          export TAG=${{ env.RELEASE_TAG }}
+          make ALL_ARCH="amd64 arm64" docker-build-all
+          make ALL_ARCH="amd64 arm64" docker-push-all

--- a/config/crd/bases/addons.cluster.x-k8s.io_clusterresourcesets.yaml
+++ b/config/crd/bases/addons.cluster.x-k8s.io_clusterresourcesets.yaml
@@ -112,6 +112,7 @@ spec:
                   Defaults to ApplyOnce. This field is immutable.
                 enum:
                 - ApplyOnce
+                - ApplyAlways
                 type: string
             required:
             - clusterSelector
@@ -439,6 +440,7 @@ spec:
                   Defaults to ApplyOnce. This field is immutable.
                 enum:
                 - ApplyOnce
+                - ApplyAlways
                 - Reconcile
                 type: string
             required:

--- a/exp/addons/api/v1beta1/clusterresourceset_types.go
+++ b/exp/addons/api/v1beta1/clusterresourceset_types.go
@@ -46,7 +46,7 @@ type ClusterResourceSetSpec struct {
 	Resources []ResourceRef `json:"resources,omitempty"`
 
 	// Strategy is the strategy to be used during applying resources. Defaults to ApplyOnce. This field is immutable.
-	// +kubebuilder:validation:Enum=ApplyOnce;Reconcile
+	// +kubebuilder:validation:Enum=ApplyOnce;ApplyAlways;Reconcile
 	// +optional
 	Strategy string `json:"strategy,omitempty"`
 }
@@ -83,6 +83,9 @@ const (
 	// ClusterResourceSetStrategyReconcile reapplies the resources managed by a ClusterResourceSet
 	// if their normalized hash changes.
 	ClusterResourceSetStrategyReconcile ClusterResourceSetStrategy = "Reconcile"
+	// ClusterResourceSetStrategyApplyAlways is the strategy where changes to the ClusterResourceSet
+	// are applied always if they exist already in clusters or created if they do not.
+	ClusterResourceSetStrategyApplyAlways ClusterResourceSetStrategy = "ApplyAlways"
 )
 
 // SetTypedStrategy sets the Strategy field to the string representation of ClusterResourceSetStrategy.

--- a/exp/addons/internal/controllers/clusterresourceset_controller.go
+++ b/exp/addons/internal/controllers/clusterresourceset_controller.go
@@ -234,7 +234,7 @@ func (r *ClusterResourceSetReconciler) getClustersByClusterResourceSetSelector(c
 		return nil, errors.Wrap(err, "failed to list clusters")
 	}
 
-	clusters := []*clusterv1.Cluster{}
+	clusters := make([]*clusterv1.Cluster, 0)
 	for i := range clusterList.Items {
 		c := &clusterList.Items[i]
 		if c.DeletionTimestamp.IsZero() {

--- a/exp/addons/internal/controllers/clusterresourceset_controller.go
+++ b/exp/addons/internal/controllers/clusterresourceset_controller.go
@@ -234,7 +234,7 @@ func (r *ClusterResourceSetReconciler) getClustersByClusterResourceSetSelector(c
 		return nil, errors.Wrap(err, "failed to list clusters")
 	}
 
-	clusters := make([]*clusterv1.Cluster, 0)
+	clusters := []*clusterv1.Cluster{}
 	for i := range clusterList.Items {
 		c := &clusterList.Items[i]
 		if c.DeletionTimestamp.IsZero() {

--- a/exp/addons/internal/controllers/clusterresourceset_controller_test.go
+++ b/exp/addons/internal/controllers/clusterresourceset_controller_test.go
@@ -1177,7 +1177,7 @@ data:
 			},
 		}
 
-		// update the configmap data
+		// update the secret data
 		t.Log("Updating the secret resource")
 		g.Expect(env.Update(ctx, secretUpdate)).To(Succeed())
 
@@ -1198,6 +1198,188 @@ data:
 			// only one resource is applied
 			resource := bindings[0].Resources[0]
 			return resource.Hash != oldHash
+		}, timeout).Should(BeTrue())
+	})
+
+	t.Run("Should create ClusterResourceSet with strategy 'AlwaysApply' and reconcile configmap only once if data has not changed", func(t *testing.T) {
+		g := NewWithT(t)
+		ns := setup(t, g)
+		defer teardown(t, g, ns)
+
+		t.Log("Updating the cluster with labels")
+		testCluster.SetLabels(labels)
+		g.Expect(env.Update(ctx, testCluster)).To(Succeed())
+
+		clusterResourceSetInstance := &addonsv1.ClusterResourceSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      clusterResourceSetName,
+				Namespace: ns.Name,
+			},
+			Spec: addonsv1.ClusterResourceSetSpec{
+				ClusterSelector: metav1.LabelSelector{
+					MatchLabels: labels,
+				},
+				Strategy:  "ApplyAlways",
+				Resources: []addonsv1.ResourceRef{{Name: configmapName, Kind: "ConfigMap"}},
+			},
+		}
+		// Create the ClusterResourceSet.
+		g.Expect(env.Create(ctx, clusterResourceSetInstance)).To(Succeed())
+
+		// Wait until ClusterResourceSetBinding is created for the Cluster
+		clusterResourceSetBindingKey := client.ObjectKey{
+			Namespace: testCluster.Namespace,
+			Name:      testCluster.Name,
+		}
+
+		// Wait until ClusterResourceSetBinding is created for the Cluster
+		t.Log("Waiting for the ClusterResourceSetBinding to be created")
+		oldHash := ""
+		var oldLastAppliedTime *metav1.Time
+		g.Eventually(func() bool {
+			binding := &addonsv1.ClusterResourceSetBinding{}
+			err := env.Get(ctx, clusterResourceSetBindingKey, binding)
+			if err != nil {
+				return false
+			}
+
+			bindings := binding.Spec.Bindings
+			// should only have one binding
+			if len(bindings) != 1 {
+				return false
+			}
+
+			// only one resource is applied
+			resource := bindings[0].Resources[0]
+			oldHash = resource.Hash
+			oldLastAppliedTime = resource.LastAppliedTime
+			return resource.Applied
+		}, timeout).Should(BeTrue())
+
+		// Get configmap obj, update the configmap
+		cmKey := client.ObjectKey{
+			Namespace: ns.Name,
+			Name:      configmapName,
+		}
+		cm := &corev1.ConfigMap{}
+		g.Expect(env.Get(ctx, cmKey, cm)).To(Succeed())
+
+		cm.Labels = map[string]string{"foo": "bar"}
+
+		// The CRS controller writes a lastAppliedTime field, which is of type metav1.Time. The precision at most a
+		// second. Therefore, if the controller re-applies the resource twice within one second, the lastAppliedTime
+		// value is unlikely to change. Our test below compares the lastAppliedTime values of two reconciles, so we wait
+		// to prevent the reconciles from running within the same second. Related issue: https://issues.k8s.io/15262
+		t.Log("Letting some time pass before updating the resource, so that lastAppliedTime will be different.")
+		time.Sleep(10 * time.Second)
+
+		// update the configmap data
+		t.Log("Updating the configmap resource")
+		g.Expect(env.Update(ctx, cm)).To(Succeed())
+
+		t.Log("Verifying that resource is not re-applied over a period of time.")
+		g.Consistently(func() bool {
+			binding := &addonsv1.ClusterResourceSetBinding{}
+			err := env.Get(ctx, clusterResourceSetBindingKey, binding)
+			if err != nil {
+				return false
+			}
+
+			bindings := binding.Spec.Bindings
+			// only one resource is applied
+			resource := bindings[0].Resources[0]
+			return oldHash == resource.Hash && oldLastAppliedTime.Equal(resource.LastAppliedTime)
+		}, timeout).Should(BeTrue())
+	})
+
+	t.Run("Should create ClusterResourceSet with strategy 'AlwaysApply' and reconcile secrets only once if data has not changed", func(t *testing.T) {
+		g := NewWithT(t)
+		ns := setup(t, g)
+		defer teardown(t, g, ns)
+
+		t.Log("Updating the cluster with labels")
+		testCluster.SetLabels(labels)
+		g.Expect(env.Update(ctx, testCluster)).To(Succeed())
+
+		clusterResourceSetInstance := &addonsv1.ClusterResourceSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      clusterResourceSetName,
+				Namespace: ns.Name,
+			},
+			Spec: addonsv1.ClusterResourceSetSpec{
+				ClusterSelector: metav1.LabelSelector{
+					MatchLabels: labels,
+				},
+				Strategy:  "ApplyAlways",
+				Resources: []addonsv1.ResourceRef{{Name: secretName, Kind: "Secret"}},
+			},
+		}
+		// Create the ClusterResourceSet.
+		g.Expect(env.Create(ctx, clusterResourceSetInstance)).To(Succeed())
+
+		// Wait until ClusterResourceSetBinding is created for the Cluster
+		clusterResourceSetBindingKey := client.ObjectKey{
+			Namespace: testCluster.Namespace,
+			Name:      testCluster.Name,
+		}
+
+		t.Log("Waiting for the ClusterResourceSetBinding to be created")
+		oldHash := ""
+		var oldLastAppliedTime *metav1.Time
+		g.Eventually(func() bool {
+			binding := &addonsv1.ClusterResourceSetBinding{}
+			err := env.Get(ctx, clusterResourceSetBindingKey, binding)
+			if err != nil {
+				return false
+			}
+
+			bindings := binding.Spec.Bindings
+			// should only have one binding
+			if len(bindings) != 1 {
+				return false
+			}
+
+			// only one resource is applied
+			resource := bindings[0].Resources[0]
+			oldHash = resource.Hash
+			oldLastAppliedTime = resource.LastAppliedTime
+			return resource.Applied
+		}, timeout).Should(BeTrue())
+
+		secretKey := client.ObjectKey{
+			Namespace: ns.Name,
+			Name:      secretName,
+		}
+		secret := &corev1.Secret{}
+		g.Expect(env.Get(ctx, secretKey, secret)).To(Succeed())
+
+		// Overwrite the Secret labels to cause the ClusterResourceSet controller to reconcile any CRS that references
+		// the Secret.
+		secret.Labels = map[string]string{"foo": "bar"}
+
+		// The CRS controller writes a lastAppliedTime field, which is of type metav1.Time. The precision at most a
+		// second. Therefore, if the controller re-applies the resource twice within one second, the lastAppliedTime
+		// value is unlikely to change. Our test below compares the lastAppliedTime values of two reconciles, so we wait
+		// to prevent the reconciles from running within the same second. Related issue: https://issues.k8s.io/15262
+		t.Log("Letting some time pass before updating the resource, so that lastAppliedTime will be different.")
+		time.Sleep(10 * time.Second)
+
+		// update the secrete, but not its data
+		t.Log("Updating the secret resource")
+		g.Expect(env.Update(ctx, secret)).To(Succeed())
+
+		t.Log("Verifying that resource is not re-applied over a period of time.")
+		g.Consistently(func() bool {
+			binding := &addonsv1.ClusterResourceSetBinding{}
+			err := env.Get(ctx, clusterResourceSetBindingKey, binding)
+			if err != nil {
+				return false
+			}
+
+			bindings := binding.Spec.Bindings
+			// only one resource is applied
+			resource := bindings[0].Resources[0]
+			return oldHash == resource.Hash && oldLastAppliedTime.Equal(resource.LastAppliedTime)
 		}, timeout).Should(BeTrue())
 	})
 }

--- a/exp/addons/internal/controllers/clusterresourceset_controller_test.go
+++ b/exp/addons/internal/controllers/clusterresourceset_controller_test.go
@@ -1271,7 +1271,7 @@ data:
 		// value is unlikely to change. Our test below compares the lastAppliedTime values of two reconciles, so we wait
 		// to prevent the reconciles from running within the same second. Related issue: https://issues.k8s.io/15262
 		t.Log("Letting some time pass before updating the resource, so that lastAppliedTime will be different.")
-		time.Sleep(10 * time.Second)
+		time.Sleep(2 * time.Second)
 
 		// update the configmap data
 		t.Log("Updating the configmap resource")
@@ -1362,7 +1362,7 @@ data:
 		// value is unlikely to change. Our test below compares the lastAppliedTime values of two reconciles, so we wait
 		// to prevent the reconciles from running within the same second. Related issue: https://issues.k8s.io/15262
 		t.Log("Letting some time pass before updating the resource, so that lastAppliedTime will be different.")
-		time.Sleep(10 * time.Second)
+		time.Sleep(2 * time.Second)
 
 		// update the secrete, but not its data
 		t.Log("Updating the secret resource")

--- a/exp/addons/internal/controllers/clusterresourceset_scope.go
+++ b/exp/addons/internal/controllers/clusterresourceset_scope.go
@@ -82,6 +82,8 @@ func newResourceReconcileScope(
 		return &reconcileApplyOnceScope{base}
 	case addonsv1.ClusterResourceSetStrategyReconcile:
 		return &reconcileStrategyScope{base}
+	case addonsv1.ClusterResourceSetStrategyApplyAlways:
+		return &reconcileStrategyScope{base}
 	default:
 		return nil
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Bumps to latest capi version https://github.com/kubernetes-sigs/cluster-api/releases/tag/v1.5.3 

This bumps to cert-manager v1.13.1 which needs to be bumped in dkp components.
