### PR TITLE
:bug: Ensure move uses mutated metadata when updating a target object

### DIFF
--- a/cmd/clusterctl/client/cluster/mover.go
+++ b/cmd/clusterctl/client/cluster/mover.go
@@ -946,12 +946,10 @@ func (o *objectMover) createTargetObject(ctx context.Context, nodeToCreate *node
 	obj := &unstructured.Unstructured{}
 	obj.SetAPIVersion(nodeToCreate.identity.APIVersion)
 	obj.SetKind(nodeToCreate.identity.Kind)
-	objKey := client.ObjectKey{
-		Namespace: nodeToCreate.identity.Namespace,
-		Name:      nodeToCreate.identity.Name,
-	}
+	obj.SetName(nodeToCreate.identity.Name)
+	obj.SetNamespace(nodeToCreate.identity.Namespace)
 
-	if err := cFrom.Get(ctx, objKey, obj); err != nil {
+	if err := cFrom.Get(ctx, client.ObjectKeyFromObject(obj), obj); err != nil {
 		return errors.Wrapf(err, "error reading %q %s/%s",
 			obj.GroupVersionKind(), obj.GetNamespace(), obj.GetName())
 	}
@@ -1006,7 +1004,7 @@ func (o *objectMover) createTargetObject(ctx context.Context, nodeToCreate *node
 			existingTargetObj := &unstructured.Unstructured{}
 			existingTargetObj.SetAPIVersion(obj.GetAPIVersion())
 			existingTargetObj.SetKind(obj.GetKind())
-			if err := cTo.Get(ctx, objKey, existingTargetObj); err != nil {
+			if err := cTo.Get(ctx, client.ObjectKeyFromObject(obj), existingTargetObj); err != nil {
 				return errors.Wrapf(err, "error reading resource for %q %s/%s",
 					existingTargetObj.GroupVersionKind(), existingTargetObj.GetNamespace(), existingTargetObj.GetName())
 			}

--- a/cmd/clusterctl/client/cluster/mover_test.go
+++ b/cmd/clusterctl/client/cluster/mover_test.go
@@ -1876,7 +1876,6 @@ func Test_objectMoverService_ensureNamespaces(t *testing.T) {
 			expectedNamespaces: []string{"namespace-1", "namespace-2"},
 		},
 		{
-
 			name: "ensureNamespaces moves namespace-2 to target which already has namespace-1",
 			fields: fields{
 				objs: cluster2.Objs(),
@@ -1956,6 +1955,7 @@ func Test_createTargetObject(t *testing.T) {
 		fromProxy Proxy
 		toProxy   Proxy
 		node      *node
+		mutators  []ResourceMutatorFunc
 	}
 
 	tests := []struct {
@@ -2076,6 +2076,52 @@ func Test_createTargetObject(t *testing.T) {
 			},
 		},
 		{
+			name: "updates object whose namespace is mutated, if it already exists and the object is not Global/GlobalHierarchy",
+			args: args{
+				fromProxy: test.NewFakeProxy().WithObjs(
+					&clusterv1.Cluster{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "foo",
+							Namespace: "ns1",
+						},
+					},
+				),
+				toProxy: test.NewFakeProxy().WithObjs(
+					&clusterv1.Cluster{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:        "foo",
+							Namespace:   "mutatedns1",
+							Annotations: map[string]string{"foo": "bar"},
+						},
+					},
+				),
+				node: &node{
+					identity: corev1.ObjectReference{
+						Kind:       "Cluster",
+						Namespace:  "ns1",
+						Name:       "foo",
+						APIVersion: "cluster.x-k8s.io/v1beta1",
+					},
+				},
+				mutators: []ResourceMutatorFunc{
+					func(u *unstructured.Unstructured) error {
+						return unstructured.SetNestedField(u.Object,
+							"mutatedns1",
+							"metadata", "namespace")
+					},
+				},
+			},
+			want: func(g *WithT, toClient client.Client) {
+				c := &clusterv1.Cluster{}
+				key := client.ObjectKey{
+					Namespace: "mutatedns1",
+					Name:      "foo",
+				}
+				g.Expect(toClient.Get(context.Background(), key, c)).ToNot(HaveOccurred())
+				g.Expect(c.Annotations).To(BeEmpty())
+			},
+		},
+		{
 			name: "should not update Global objects",
 			args: args{
 				fromProxy: test.NewFakeProxy().WithObjs(
@@ -2163,7 +2209,7 @@ func Test_createTargetObject(t *testing.T) {
 				fromProxy: tt.args.fromProxy,
 			}
 
-			err := mover.createTargetObject(ctx, tt.args.node, tt.args.toProxy, nil, sets.New[string]())
+			err := mover.createTargetObject(ctx, tt.args.node, tt.args.toProxy, tt.args.mutators, sets.New[string]())
 			if tt.wantErr {
 				g.Expect(err).To(HaveOccurred())
 				return


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
The `createTargetObject` function is called as part of the move operation. It creates the target object, i.e. the object on the target cluster. If the target object already exists, the function updates the object. 

Previously, the function fixed the name and namespace of the target object before it applied the experimental mutators. If some mutator modified the namespace of the target object, the function would continue to use the namespace established before the mutators were applied.

This adds a new (failing) unit test, and ensures that the target object namespace reflects the changes made by the experimental mutators. 

--

We discovered this issue in a more complex scenario than the one in the new unit test.

In our scenario, we started the move operation, passing a mutator that changes the target namespace. The `createTargetObject` function try to create a ClusterClass in the target namespace. However, CAREN would  copy the same ClusterClass to the namespace, and so the function would try to update it.

Because of the bug fixed here, the function read the ClusterClass in the default namespace on the target cluster, and then tried to update the ClusterClass in the target namespace, all the while using the UID and resource version of the ClusterClass in the default namespace:
https://github.com/mesosphere/cluster-api//blob/d6afeb8e33d9565680345b84e900c1d78a8ab76f/cmd/clusterctl/client/cluster/mover.go#L1005-L1019

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->