### PR TITLE
:bug: increase the timeout when creating and upgrading CAPI controllers

### DIFF
--- a/cmd/clusterctl/client/cluster/client.go
+++ b/cmd/clusterctl/client/cluster/client.go
@@ -242,13 +242,13 @@ func retryWithExponentialBackoff(ctx context.Context, opts wait.Backoff, operati
 
 // newWriteBackoff creates a new API Machinery backoff parameter set suitable for use with clusterctl write operations.
 func newWriteBackoff() wait.Backoff {
-	// Return a exponential backoff configuration which returns durations for a total time of ~40s.
-	// Example: 0, .5s, 1.2s, 2.3s, 4s, 6s, 10s, 16s, 24s, 37s
+	// Return a exponential backoff configuration which returns durations for a total time of ~6m.
+	// Example: 0, .5s, 1.2s, 2.3s, 4s, 6s, 10s, 16s, 24s, 37s, 56s, 84s, 126s, 190s
 	// Jitter is added as a random fraction of the duration multiplied by the jitter factor.
 	return wait.Backoff{
 		Duration: 500 * time.Millisecond,
 		Factor:   1.5,
-		Steps:    10,
+		Steps:    14,
 		Jitter:   0.4,
 	}
 }

--- a/exp/runtime/internal/controllers/warmup.go
+++ b/exp/runtime/internal/controllers/warmup.go
@@ -33,7 +33,7 @@ import (
 )
 
 const (
-	defaultWarmupTimeout  = 60 * time.Second
+	defaultWarmupTimeout  = 5 * time.Minute
 	defaultWarmupInterval = 2 * time.Second
 )
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
This PR is an attempt to fix the race conditions we've been seeing when creating and upgrading CAPI controllers.
There are 2 fixes here:
1. Extend CAPI's warm-up timeout to prevent it from getting restarted prematurely when waiting for RuntimeExtentions are starting up.
2. Extend clusterctl timeout when creating and upgrading CAPI controllers.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->